### PR TITLE
Add checksum and other react-data-* attributes

### DIFF
--- a/spec/exec.js
+++ b/spec/exec.js
@@ -19,3 +19,4 @@ require("./context");
 require("./lifecycle-methods");
 require("./special-cases");
 require("./template");
+require("./parity");

--- a/spec/parity.js
+++ b/spec/parity.js
@@ -1,0 +1,42 @@
+import { default as React } from "react";
+import { renderToString as reactRenderToString } from "react-dom/server";
+
+import { renderToString } from "../src";
+
+
+describe("parity", () => {
+  it("renderToString has parity with ReactDOMServer.renderToString", () => {
+
+    const Foo = () => (
+      <div>
+        <h1 id="foobar">Hello, world</h1>
+      </div>
+    );
+
+    const Bar = () => (
+      <div>
+        <Foo />
+        <ul>
+          <li>first</li>
+          <li>second</li>
+        </ul>
+      </div>
+    );
+
+    class FooBar extends React.Component {
+      render () {
+        return (
+          <div>
+            <h1>Foobar</h1>
+            <Bar />
+          </div>
+        );
+      }
+    }
+
+    return renderToString(<FooBar />)
+      .then(htmlString => {
+        expect(htmlString).to.equal(reactRenderToString(<FooBar />));
+      });
+  });
+});

--- a/src/checksum.js
+++ b/src/checksum.js
@@ -1,0 +1,16 @@
+const { adler32 } = require("./util");
+
+const TAG_END = /\/?>/;
+const COMMENT_START = /^<\!\-\-/;
+
+module.exports = function addChecksumToMarkup (markup) {
+  const checksum = adler32(markup);
+  if (COMMENT_START.test(markup)) {
+    return markup;
+  } else {
+    return markup.replace(
+      TAG_END,
+      ` data-react-checksum="${checksum}"$&`
+    );
+  }
+};

--- a/src/util.js
+++ b/src/util.js
@@ -17,10 +17,42 @@ const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
 const concatAll = streams =>
   streams.reduce((memo, stream) => memo.concat(stream), most.empty());
 
+/* eslint-disable no-magic-numbers, no-bitwise, max-statements */
+const adler32 = data => {
+  const MOD = 65521;
+  let a = 1;
+  let b = 0;
+  let i = 0;
+  const l = data.length;
+  // eslint-disable-next-line
+  let m = l & ~0x3;
+  while (i < m) {
+    const n = Math.min(i + 4096, m);
+    for (; i < n; i += 4) {
+      b += (
+        (a += data.charCodeAt(i)) +
+        (a += data.charCodeAt(i + 1)) +
+        (a += data.charCodeAt(i + 2)) +
+        (a += data.charCodeAt(i + 3))
+      );
+    }
+    a %= MOD;
+    b %= MOD;
+  }
+  for (; i < l; i++) {
+    b += (a += data.charCodeAt(i));
+  }
+  a %= MOD;
+  b %= MOD;
+  return a | (b << 16);
+};
+/* eslint-enable d */
+
 
 module.exports = {
   toDashCase,
   htmlStringEscape,
   hasOwn,
-  concatAll
+  concatAll,
+  adler32
 };


### PR DESCRIPTION
cc @divmain @kenwheeler this change will ensure that `react-data-{checksum,reactroot,reactid}` attributes are rendered correctly. The checksum attribute is only attached when using `renderToString` as its impossible to know when streaming.

This breaks pretty much all the other tests because they are all asserting on output that does not contain these required attributes. I wasn't sure how you wanted to approach that, so I left it alone until we can decide on the best testing strategy.

We can either:

* Update all string literals to include the attributes. Thats kind of a pain though.
* Use snapshot testing 📸 
* Use `ReactDOMServer.renderToString` whenever possible (like I did in the parity test) and just assert that our implementation matches React's.