### PR TITLE
[WIP] Parse style prop attributes correctly

### DIFF
--- a/spec/exec.js
+++ b/spec/exec.js
@@ -20,3 +20,4 @@ require("./deep-hierarchies");
 require("./lifecycle-methods");
 require("./special-cases");
 require("./template");
+require("./styles");

--- a/spec/parity/styles.js
+++ b/spec/parity/styles.js
@@ -1,0 +1,20 @@
+import { default as React } from "react";
+
+
+const Component = () => (
+  <div
+    style={{
+      padding: 10,
+      margin: 15,
+      opacity: 1
+    }}
+  />
+);
+
+
+const description = "Style prop";
+
+export {
+  description,
+  Component
+};

--- a/spec/parity/styles.js
+++ b/spec/parity/styles.js
@@ -6,13 +6,16 @@ const Component = () => (
     style={{
       padding: 10,
       margin: 15,
-      opacity: 1
+      opacity: 1,
+      animationIterationCount: 1,
+      animationName: "foobar",
+      fontSize: 15
     }}
   />
 );
 
 
-const description = "Style prop";
+const description = "style prop";
 
 export {
   description,

--- a/spec/styles.js
+++ b/spec/styles.js
@@ -16,6 +16,6 @@ const Foobar = () => (
   />
 );
 
-describe("a hierarchy three levels deep", () => {
+describe("the style prop", () => {
   checkParity(Foobar, {});
 });

--- a/spec/styles.js
+++ b/spec/styles.js
@@ -1,7 +1,9 @@
 import { default as React } from "react";
 
+import { checkParity } from "./_util";
 
-const Component = () => (
+
+const Foobar = () => (
   <div
     style={{
       padding: 10,
@@ -14,10 +16,6 @@ const Component = () => (
   />
 );
 
-
-const description = "style prop";
-
-export {
-  description,
-  Component
-};
+describe("a hierarchy three levels deep", () => {
+  checkParity(Foobar, {});
+});

--- a/src/render/attrs/index.js
+++ b/src/render/attrs/index.js
@@ -2,7 +2,7 @@ const { map, isFunction } = require("lodash/fp");
 const { hasOwn } = require("../util");
 
 const transformAttrKey = require("./transform-attr-key");
-
+const { renderStyleAttribute } = require("./style");
 
 const mapWithKey = map.convert({ cap: false });
 
@@ -36,7 +36,7 @@ function renderAttrs (attrs) {
       if (attrVal === true) {
         attrVal = "";
       } else if (attrKey === "style" && typeof attrVal === "object") {
-        attrVal = `="${styleObjToString(attrVal)}"`;
+        attrVal = `="${renderStyleAttribute(attrVal)}"`;
       } else {
         attrVal = `="${attrVal}"`;
       }
@@ -48,7 +48,7 @@ function renderAttrs (attrs) {
   return attrString.join("");
 }
 
-const mapPairToString = mapWithKey((val, key) => `${key}:${val}`);
+const mapPairToString = mapWithKey((val, key) => `${key}:${key}`);
 function styleObjToString (obj) {
   return mapPairToString(obj).join(";");
 }

--- a/src/render/attrs/index.js
+++ b/src/render/attrs/index.js
@@ -1,11 +1,8 @@
-const { map, isFunction } = require("lodash/fp");
+const { isFunction } = require("lodash/fp");
 const { hasOwn } = require("../util");
 
 const transformAttrKey = require("./transform-attr-key");
 const { renderStyleAttribute } = require("./style");
-
-const mapWithKey = map.convert({ cap: false });
-
 
 const attrsNotToRender = {
   children: true,
@@ -47,11 +44,5 @@ function renderAttrs (attrs) {
 
   return attrString.join("");
 }
-
-const mapPairToString = mapWithKey((val, key) => `${key}:${key}`);
-function styleObjToString (obj) {
-  return mapPairToString(obj).join(";");
-}
-
 
 module.exports = renderAttrs;

--- a/src/render/attrs/is-unitless-number.js
+++ b/src/render/attrs/is-unitless-number.js
@@ -1,0 +1,42 @@
+/**
+ * Most numeric style attributes require a "px"
+ * suffix after the value. This map contains special
+ * values which are considered unitless (no suffix)
+ */
+module.exports = {
+  animationIterationCount: true,
+  borderImageOutset: true,
+  borderImageSlice: true,
+  borderImageWidth: true,
+  boxFlex: true,
+  boxFlexGroup: true,
+  boxOrdinalGroup: true,
+  columnCount: true,
+  flex: true,
+  flexGrow: true,
+  flexPositive: true,
+  flexShrink: true,
+  flexNegative: true,
+  flexOrder: true,
+  gridRow: true,
+  gridColumn: true,
+  fontWeight: true,
+  lineClamp: true,
+  lineHeight: true,
+  opacity: true,
+  order: true,
+  orphans: true,
+  tabSize: true,
+  widows: true,
+  zIndex: true,
+  zoom: true,
+  // SVG-related properties
+  fillOpacity: true,
+  floodOpacity: true,
+  stopOpacity: true,
+  strokeDasharray: true,
+  strokeDashoffset: true,
+  strokeMiterlimit: true,
+  strokeOpacity: true,
+  strokeWidth: true
+};

--- a/src/render/attrs/style.js
+++ b/src/render/attrs/style.js
@@ -1,11 +1,14 @@
 const { hasOwn } = require("../util");
 const { map } = require("lodash/fp");
 const { isNumber } = require("lodash");
+const { hypenateStyleName } = require("../util");
 const isUnitlessNumber = require("./is-unitless-number");
 
 const mapWithKey = map.convert({ cap: false });
 
-const mapToParsedStyles = mapWithKey(parseStyle);
+const mapToParsedStyles = mapWithKey((value, name) => (
+  `${hypenateStyleName(name)}:${parseStyleValue(name, value)};`
+));
 
 /**
  * Maps and transforms the object passed as the
@@ -15,17 +18,6 @@ const mapToParsedStyles = mapWithKey(parseStyle);
  */
 function renderStyleAttribute (styles) {
   return mapToParsedStyles(styles).join("");
-}
-
-/**
- * Parses the style value and returns a stringified
- * @param {String} value style attribute parsedValue
- * @param {String} name style attribute name
- * @return {String} parsed style key/pair value
- */
-function parseStyle (value, name) {
-  const parsedValue = parseStyleValue(name, value);
-  return `${name}:${parsedValue};`;
 }
 
 /**

--- a/src/render/attrs/style.js
+++ b/src/render/attrs/style.js
@@ -1,0 +1,59 @@
+const { hasOwn } = require("../util");
+const { map } = require("lodash/fp");
+const { isNumber } = require("lodash");
+const isUnitlessNumber = require("./is-unitless-number");
+
+const mapWithKey = map.convert({ cap: false });
+
+const mapToParsedStyles = mapWithKey(parseStyle);
+
+/**
+ * Maps and transforms the object passed as the
+ * style prop to a stringified style list.
+ * @param {Object} styles style properties
+ * @returns {String} parsed and stringified style
+ */
+function renderStyleAttribute (styles) {
+  return mapToParsedStyles(styles).join("");
+}
+
+/**
+ * Parses the style value and returns a stringified
+ * @param {String} value style attribute parsedValue
+ * @param {String} name style attribute name
+ * @return {String} parsed style key/pair value
+ */
+function parseStyle (value, name) {
+  const parsedValue = parseStyleValue(name, value);
+  return `${name}:${parsedValue};`;
+}
+
+/**
+ * Adapted from React core's dangerousStyleValue module.
+ * @param {String} name style attribute name
+ * @param {String} value style attribute value
+ * @returns {String} parsed style value
+ * @see https://github.com/facebook/react/blob/32f5b034ed229d048f76ae74e18d270edc801dbf/src/renderers/dom/shared/dangerousStyleValue.js
+ */
+function parseStyleValue (name, value) {
+  // Use loose equality check to catch undefined as well.
+  // eslint-disable-next-line eqeqeq
+  if (value == null || typeof value === "boolean" || value === "") {
+    return "";
+  }
+  // All numeric properties that are not registered as
+  // unitless numbers will received a "px" suffix.
+  if (
+    isNumber(value) && value !== 0
+    && !(hasOwn(isUnitlessNumber, name) && isUnitlessNumber[name])
+  ) {
+    return `${value}px`;
+  }
+  return `${value}`.trim();
+}
+
+module.exports = {
+  renderStyleAttribute
+};
+
+

--- a/src/render/attrs/style.js
+++ b/src/render/attrs/style.js
@@ -1,13 +1,13 @@
 const { hasOwn } = require("../util");
 const { map } = require("lodash/fp");
 const { isNumber } = require("lodash");
-const { hypenateStyleName } = require("../util");
+const { hyphenateStyleName } = require("../util");
 const isUnitlessNumber = require("./is-unitless-number");
 
 const mapWithKey = map.convert({ cap: false });
 
 const mapToParsedStyles = mapWithKey((value, name) => (
-  `${hypenateStyleName(name)}:${parseStyleValue(name, value)};`
+  `${hyphenateStyleName(name)}:${parseStyleValue(name, value)};`
 ));
 
 /**

--- a/src/render/attrs/style.js
+++ b/src/render/attrs/style.js
@@ -25,7 +25,7 @@ function renderStyleAttribute (styles) {
  * @param {String} name style attribute name
  * @param {String} value style attribute value
  * @returns {String} parsed style value
- * @see https://github.com/facebook/react/blob/32f5b034ed229d048f76ae74e18d270edc801dbf/src/renderers/dom/shared/dangerousStyleValue.js
+ * @see https://github.com/facebook/react/blob/master/src/renderers/dom/shared/dangerousStyleValue.js
  */
 function parseStyleValue (name, value) {
   // Use loose equality check to catch undefined as well.

--- a/src/render/util.js
+++ b/src/render/util.js
@@ -9,18 +9,18 @@ const htmlStringEscape = str => encode(str, ENCODE_OPTS);
 const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
 /**
  * Takes a camelCase string and returns a hyphenated version. Adapted
- * from the hypenateStyleName module available in the fbjs repo, used by React.
+ * from the hyphenateStyleName module available in the fbjs repo, used by React.
  * In addition to hyphenating the name it also replaces the "ms" prefix with
  * "-ms-" as recommended by Modernizr
  * @param {String} string style attribute name
- * @returns {String} hypenate style attribute name
+ * @returns {String} hyphenate style attribute name
  * @see https://modernizr.com/docs/#prefixed
  * @see https://github.com/facebook/fbjs/blob/e66ba20ad5be433eb54423f2b097d829324d9de6/packages/fbjs/src/core/hyphenateStyleName.js
  */
-const hypenateStyleName = (string) => kebabCase(string).replace(/^ms-/, "-ms-");
+const hyphenateStyleName = (string) => kebabCase(string).replace(/^ms-/, "-ms-");
 
 module.exports = {
   htmlStringEscape,
   hasOwn,
-  hypenateStyleName
+  hyphenateStyleName
 };

--- a/src/render/util.js
+++ b/src/render/util.js
@@ -15,7 +15,7 @@ const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
  * @param {String} string style attribute name
  * @returns {String} hyphenate style attribute name
  * @see https://modernizr.com/docs/#prefixed
- * @see https://github.com/facebook/fbjs/blob/e66ba20ad5be433eb54423f2b097d829324d9de6/packages/fbjs/src/core/hyphenateStyleName.js
+ * @see https://github.com/facebook/fbjs/blob/master/packages/fbjs/src/core/hyphenateStyleName.js
  */
 const hyphenateStyleName = (string) => kebabCase(string).replace(/^ms-/, "-ms-");
 

--- a/src/render/util.js
+++ b/src/render/util.js
@@ -1,4 +1,5 @@
 const { encode } = require("he");
+const { kebabCase } = require("lodash");
 
 
 const ENCODE_OPTS = { strict: true };
@@ -6,9 +7,20 @@ const ENCODE_OPTS = { strict: true };
 
 const htmlStringEscape = str => encode(str, ENCODE_OPTS);
 const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
-
+/**
+ * Takes a camelCase string and returns a hyphenated version. Adapted
+ * from the hypenateStyleName module available in the fbjs repo, used by React.
+ * In addition to hyphenating the name it also replaces the "ms" prefix with
+ * "-ms-" as recommended by Modernizr
+ * @param {String} string style attribute name
+ * @returns {String} hypenate style attribute name
+ * @see https://modernizr.com/docs/#prefixed
+ * @see https://github.com/facebook/fbjs/blob/e66ba20ad5be433eb54423f2b097d829324d9de6/packages/fbjs/src/core/hyphenateStyleName.js
+ */
+const hypenateStyleName = (string) => kebabCase(string).replace(/^ms-/, "-ms-");
 
 module.exports = {
   htmlStringEscape,
-  hasOwn
+  hasOwn,
+  hypenateStyleName
 };


### PR DESCRIPTION
This is ~most of the work needed towards correctly rendering the `style` prop, bringing rapscallion closer to parity with `ReactDOMServer`. The two major improvements are:

* Add the "px" prefix when it's needed
* Covert attribute names to kebab-case

It also breaks out the style parsing into its own module for clarity. I'd like to add some more tests to verify behavior before merging but wanted to open for review.

@divmain for parity tests I think the approach will need to be adjusted. We'll want to be able to be more granular with the tests without having separate files for each test case since they all relate to a single domain. For example, it would be nice to have individual tests for unitless numbers, "px" prefixing, attribute names, etc.
