### PR TITLE
fixing empty style attribute -  checksum was invalid

### DIFF
--- a/src/render/attrs/index.js
+++ b/src/render/attrs/index.js
@@ -26,7 +26,10 @@ function renderAttrs (attrs) {
     ) {
       let attrVal = attrs[attrKey];
 
-      if (!attrVal || isFunction(attrVal)) { continue; }
+      if (
+        !attrVal || isFunction(attrVal) ||
+        !(Object.keys(attrVal).length > 0)
+      ) { continue; }
 
       attrKey = transformAttrKey(attrKey);
 


### PR DESCRIPTION
Sometimes an empty style attribute would be put onto an HTML element.

Here's some photo's that show the issue:
http://imgur.com/a/tYRUP

The only change that was needed was within /attrs/index.js. Checking if the attrVal is over length of zero.