### PR TITLE
Reduce overhead accessing process.env in benchmark

### DIFF
--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -6,6 +6,10 @@ import { render } from "../src";
 import { time } from "./_util";
 
 
+// Accessing process.env.NODE_ENV is expensive.
+// Replace process.env to equivalent plain JS objects.
+process.env = Object.assign({}, process.env);
+
 // Make sure React is in production mode.
 process.env.NODE_ENV = "production";
 


### PR DESCRIPTION
Accessing `process.env.NODE_ENV` is quite expensive. (See https://github.com/raxjs/server-side-rendering-comparison/pull/5)

The overhead can be reduced by replacing `process.env` to equivalent plain JS objects. (Ideal solution would be to use minified build...)

Before the patch:
```
Starting benchmark for 10 concurrent render operations...
renderToString took 17.015370214 seconds
rapscallion, no caching took 16.433021023 seconds; ~1.03x faster
rapscallion, caching DIVs took 3.563874972 seconds; ~4.77x faster
rapscallion, caching DIVs (second time) took 1.517760887 seconds; ~11.21x faster
rapscallion, caching Components took 1.930695494 seconds; ~8.81x faster
rapscallion, caching Components (second time) took 1.562633151 seconds; ~10.88x faster
```

After the patch:
```
Starting benchmark for 10 concurrent render operations...
renderToString took 7.380151613 seconds
rapscallion, no caching took 12.990898374 seconds; ~0.56x faster
rapscallion, caching DIVs took 3.098766871 seconds; ~2.38x faster
rapscallion, caching DIVs (second time) took 1.492479727 seconds; ~4.94x faster
rapscallion, caching Components took 1.842742489 seconds; ~4x faster
rapscallion, caching Components (second time) took 1.387480868 seconds; ~5.31x faster
```

Benchmark is run on Node v7.6.0.