### PR TITLE
Fixing double render for html elements with ommitted closed tags

### DIFF
--- a/src/render/traverse.js
+++ b/src/render/traverse.js
@@ -5,6 +5,23 @@ const renderAttrs = require("./attrs");
 
 const { REACT_ID } = require("../symbols");
 
+const omittedCloseTags = {
+  "area": true,
+  "base": true,
+  "br": true,
+  "col": true,
+  "embed": true,
+  "hr": true,
+  "img": true,
+  "input": true,
+  "keygen": true,
+  "link": true,
+  "meta": true,
+  "param": true,
+  "source": true,
+  "track": true,
+  "wbr": true
+};
 
 function renderChildrenArray (seq, children, context) {
   for (let idx = 0; idx < children.length; idx++) {
@@ -40,13 +57,15 @@ function renderNode (seq, node, context) {
   seq.emit(() => `<${node.type}`);
   seq.emit(() => renderAttrs(node.props, seq));
   seq.emit(() => REACT_ID);
-  seq.emit(() => ">");
+  seq.emit(() => omittedCloseTags[node.type] ? "/>" : ">");
   if (node.props.dangerouslySetInnerHTML) {
     seq.emit(() => node.props.dangerouslySetInnerHTML.__html || "");
   } else {
     seq.delegate(() => renderChildren(seq, node.props.children, context));
   }
-  seq.emit(() => `</${node.type}>`);
+  if (!omittedCloseTags[node.type]) {
+    seq.emit(() => `</${node.type}>`);
+  }
 }
 
 /**


### PR DESCRIPTION
Discussed on https://github.com/FormidableLabs/rapscallion/pull/45#issuecomment-283854298
and https://github.com/FormidableLabs/rapscallion/issues/44#issuecomment-283539497

Before: `<br/>` would be rendered as `<br></br>`

After: `<br/>` is rendered as `<br/>`

Redoing this PR for a clean commit message + lint check