### PR TITLE
Use escape-html instead of he lib for html encoding for performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "adler-32": "^1.0.0",
     "bluebird": "^3.4.7",
-    "he": "^1.1.1",
+    "escape-html": "^1.0.3",
     "lodash": "^4.17.4"
   }
 }

--- a/src/render/util.js
+++ b/src/render/util.js
@@ -1,11 +1,13 @@
-const { encode } = require("he");
+const escapeHtml = require("escape-html");
 const { kebabCase } = require("lodash");
 
+const htmlStringEscape = str => {
+  if (typeof str === "boolean" || typeof str === "number") {
+    return String(str);
+  }
+  return escapeHtml(str);
+};
 
-const ENCODE_OPTS = { strict: true };
-
-
-const htmlStringEscape = str => encode(str, ENCODE_OPTS);
 const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
 /**
  * Takes a camelCase string and returns a hyphenated version. Adapted


### PR DESCRIPTION
This PR switches to escape-html for encoding for a performance boost, which React is using a variant of. But, we might need that exact variant, since it has changed one of the escaped characters.

https://github.com/facebook/react/commit/d6e70586b77d4d52c4046b007b8a619e4463058c
https://github.com/facebook/react/blob/c78464f8ea9a5b00ec80252d20a71a1482210e57/src/renderers/dom/shared/escapeTextContentForBrowser.js


Profile showed the encoding taking up a good amount of time:
![image](https://cloud.githubusercontent.com/assets/848347/23559689/ad84c0ba-ffec-11e6-8709-65484d28f3ee.png)

Before
```
Starting benchmark for 10 concurrent render operations...
renderToString took 4.652867110 seconds
rapscallion, no caching took 6.882144518 seconds; ~0.67x faster
rapscallion, caching DIVs took 2.418307051 seconds; ~1.92x faster
rapscallion, caching DIVs (second time) took 1.737559321 seconds; ~2.67x faster
rapscallion, caching Components took 1.804300293 seconds; ~2.57x faster
rapscallion, caching Components (second time) took 1.434869575 seconds; ~3.24x faster
```

After
```
Starting benchmark for 10 concurrent render operations...
renderToString took 4.740671105 seconds
rapscallion, no caching took 4.692482413 seconds; ~1.01x faster
rapscallion, caching DIVs took 2.110185840 seconds; ~2.24x faster
rapscallion, caching DIVs (second time) took 1.348428223 seconds; ~3.51x faster
rapscallion, caching Components took 1.621372271 seconds; ~2.92x faster
rapscallion, caching Components (second time) took 1.335237130 seconds; ~3.55x faster
```

Benchmark ran on Node v7.4, 2.9ghz i5 Early 2015 Macbook Pro
