### PR TITLE
Adding some failing attribute rendering tests.

### DIFF
--- a/spec/_util.js
+++ b/spec/_util.js
@@ -15,17 +15,20 @@ function resolveStreamOnDone (stream, cb) {
   });
 }
 
-
 export const checkParity = (Component, props) => {
+  checkElementParity(<Component {...props} />);
+};
+
+export const checkElementParity = (element) => {
   it("has parity with React#renderToString via Render#toPromise", () => {
-    return render(<Component {...props} />)
+    return render(element)
       .toPromise()
       .then(htmlString => {
-        expect(htmlString).to.equal(reactRenderToString(<Component {...props} />));
+        expect(htmlString).to.equal(reactRenderToString(element));
       });
   });
   it("has parity with React#renderToString via Render#toStream", () => {
-    const stream = render(<Component {...props} />).toStream();
+    const stream = render(element).toStream();
 
     let output = "";
     return resolveStreamOnDone(stream, segment => output += segment)
@@ -33,7 +36,7 @@ export const checkParity = (Component, props) => {
         const checksum = stream.checksum();
         output = output.replace(TAG_END, ` data-react-checksum="${checksum}"$&`);
 
-        expect(output).to.equal(reactRenderToString(<Component {...props} />));
+        expect(output).to.equal(reactRenderToString(element));
       });
   });
 };

--- a/spec/attributes.js
+++ b/spec/attributes.js
@@ -137,17 +137,17 @@ describe("property to attribute mapping", () => {
     });
 
     // this probably is just masking programmer error, but it is existing behavior.
-    describe("className prop with true value", () => {
+    describe("htmlFor prop with true value", () => {
       checkElementParity(<div htmlFor={true} />); // eslint-disable-line react/jsx-boolean-value
     });
 
     // this probably is just masking programmer error, but it is existing behavior.
-    describe("className prop with false value", () => {
+    describe("htmlFor prop with false value", () => {
       checkElementParity(<div htmlFor={false} />);
     });
 
     // this probably is just masking programmer error, but it is existing behavior.
-    describe("className prop with false value", () => {
+    describe("htmlFor prop with false value", () => {
       checkElementParity(<div htmlFor />);
     });
 

--- a/spec/attributes.js
+++ b/spec/attributes.js
@@ -1,0 +1,208 @@
+import { default as React } from "react";
+
+import { checkElementParity } from "./_util";
+
+describe("property to attribute mapping", () => {
+
+  describe("string properties", () => {
+    describe("simple numbers", () => {
+      checkElementParity(<div width={30} />);
+    });
+
+    describe("simple strings", () => {
+      checkElementParity(<div width={'30'} />);
+    });
+
+    // this seems like it might mask programmer error, but it's existing behavior.
+    describe("string prop with true value", () => {
+      checkElementParity(<a href={true} />); // eslint-disable-line react/jsx-boolean-value
+    });
+
+    // this seems like it might mask programmer error, but it's existing behavior.
+    describe("string prop with false value", () => {
+      checkElementParity(<a href={false} />);
+    });
+
+    // this seems like somewhat odd behavior, as it isn't how <a html> works
+    // in HTML, but it's existing behavior.
+    describe("string prop with true value", () => {
+      checkElementParity(<a href />); // eslint-disable-line react/jsx-boolean-value
+    });
+  });
+
+  describe("boolean properties", () => {
+    describe("boolean prop with true value", () => {
+      checkElementParity(<div hidden={true} />); // eslint-disable-line react/jsx-boolean-value
+    });
+
+    describe("boolean prop with false value", () => {
+      checkElementParity(<div hidden={false} />);
+    });
+
+    describe("boolean prop with missing value", () => {
+      checkElementParity(<div hidden />); // eslint-disable-line react/jsx-boolean-value
+    });
+
+    describe("boolean prop with self value", () => {
+      checkElementParity(<div hidden="hidden" />);
+    });
+
+    // this does not seem like correct behavior, since hidden="" in HTML indicates
+    // that the boolean property is present. however, it is how the current code
+    // behaves, so the test is included here.
+    describe("boolean prop with \"\" value", () => {
+      checkElementParity(<div hidden="" />);
+    });
+
+    // this seems like it might mask programmer error, but it's existing behavior.
+    describe("boolean prop with string value", () => {
+      checkElementParity(<div hidden="foo" />);
+    });
+
+    // this seems like it might mask programmer error, but it's existing behavior.
+    describe("boolean prop with array value", () => {
+      checkElementParity(<div hidden={["foo", "bar"]} />);
+    });
+
+    // this seems like it might mask programmer error, but it's existing behavior.
+    describe("boolean prop with object value", () => {
+      checkElementParity(<div hidden={{ foo: "bar" }} />);
+    });
+
+    // this seems like it might mask programmer error, but it's existing behavior.
+    describe("boolean prop with non-zero number value", () => {
+      checkElementParity(<div hidden={10} />);
+    });
+
+    // this seems like it might mask programmer error, but it's existing behavior.
+    describe("boolean prop with zero value", () => {
+      checkElementParity(<div hidden={0} />);
+    });
+  });
+
+  describe("download property (combined boolean/string attribute)", () => {
+    describe("download prop with true value", () => {
+      checkElementParity(<a download={true} />); // eslint-disable-line react/jsx-boolean-value
+    });
+
+    describe("download prop with false value", () => {
+      checkElementParity(<a download={false} />);
+    });
+
+    describe("download prop with no value", () => {
+      checkElementParity(<a download />);
+    });
+
+    describe("download prop with string value", () => {
+      checkElementParity(<a download="myfile" />);
+    });
+
+    describe("download prop with string \"true\" value", () => {
+      checkElementParity(<a download={'true'} />);
+    });
+  });
+
+  describe("className property", () => {
+    describe("className prop with string value", () => {
+      checkElementParity(<div className="myClassName" />);
+    });
+
+    describe('className prop with empty string value', () => {
+      checkElementParity(<div className="" />);
+    });
+
+    // this probably is just masking programmer error, but it is existing behavior.
+    describe('className prop with true value', () => {
+      checkElementParity(<div className={true} />); // eslint-disable-line react/jsx-boolean-value
+    });
+
+    // this probably is just masking programmer error, but it is existing behavior.
+    describe("className prop with false value", () => {
+      checkElementParity(<div className={false} />);
+    });
+
+    // this probably is just masking programmer error, but it is existing behavior.
+    describe("className prop with false value", () => {
+      checkElementParity(<div className />); // eslint-disable-line react/jsx-boolean-value
+    });
+  });
+
+  describe("htmlFor property", () => {
+    describe("htmlFor with string value", () => {
+      checkElementParity(<div htmlFor="myFor" />);
+    });
+
+    describe("htmlFor with an empty string", () => {
+      checkElementParity(<div htmlFor="" />);
+    });
+
+    // this probably is just masking programmer error, but it is existing behavior.
+    describe("className prop with true value", () => {
+      checkElementParity(<div htmlFor={true} />); // eslint-disable-line react/jsx-boolean-value
+    });
+
+    // this probably is just masking programmer error, but it is existing behavior.
+    describe("className prop with false value", () => {
+      checkElementParity(<div htmlFor={false} />);
+    });
+
+    // this probably is just masking programmer error, but it is existing behavior.
+    describe("className prop with false value", () => {
+      checkElementParity(<div htmlFor />);
+    });
+
+  });
+
+  describe("props with special meaning in React", () => {
+    describe("no ref attribute", () => {
+      class RefComponent extends React.Component {
+        render () {
+          return <div ref="foo" />; // eslint-disable-line react/no-string-refs
+        }
+      }
+      checkElementParity(<RefComponent />);
+    });
+
+    describe("no children attribute", () => {
+      checkElementParity(React.createElement("div", {}, "foo"));
+    });
+
+    describe("no key attribute", () => {
+      checkElementParity(<div key="foo" />);
+    });
+
+    describe("no dangerouslySetInnerHTML attribute", () => {
+      checkElementParity(<div dangerouslySetInnerHTML={{ __html: "foo" }} />);
+    });
+  });
+
+  describe("unknown attributes", () => {
+    describe("no unknown attributes", () => {
+      checkElementParity(<div foo="bar" />, 1);
+    });
+
+    describe("unknown data- attributes", () => {
+      checkElementParity(<div data-foo="bar" />);
+    });
+
+    describe("no unknown attributes for non-standard elements", () => {
+      checkElementParity(<nonstandard foo="bar" />, 1);
+    });
+
+    describe("unknown attributes for custom elements", () => {
+      checkElementParity(<custom-element foo="bar" />);
+    });
+
+    describe("unknown attributes for custom elements using is", () => {
+      checkElementParity(<div is="custom-element" foo="bar" />);
+    });
+  });
+
+  describe("no HTML events", () => {
+    checkElementParity(<div onClick={() => {}} />);
+  });
+
+  describe("non HTML events", () => {
+    checkElementParity(<div onFoo={() => {}} />);
+  });
+});

--- a/spec/attributes.js
+++ b/spec/attributes.js
@@ -107,12 +107,12 @@ describe("property to attribute mapping", () => {
       checkElementParity(<div className="myClassName" />);
     });
 
-    describe('className prop with empty string value', () => {
+    describe("className prop with empty string value", () => {
       checkElementParity(<div className="" />);
     });
 
     // this probably is just masking programmer error, but it is existing behavior.
-    describe('className prop with true value', () => {
+    describe("className prop with true value", () => {
       checkElementParity(<div className={true} />); // eslint-disable-line react/jsx-boolean-value
     });
 

--- a/spec/children.js
+++ b/spec/children.js
@@ -1,7 +1,7 @@
 import { default as React } from "react";
 import { range } from "lodash";
 
-import { checkParity } from "./_util";
+import { checkParity, checkElementParity } from "./_util";
 
 
 const Foo = () => (
@@ -25,5 +25,129 @@ const Bar = () => (
 describe("children", () => {
   describe("specified as an array", () => {
     checkParity(Bar, {});
+  });
+});
+
+describe("elements with text children", () => {
+  describe("a div with text", () => {
+    checkElementParity(<div>Text</div>);
+  });
+
+  describe("a div with text with flanking whitespace", () => {
+    checkElementParity(<div>  Text </div>);
+  });
+
+  describe("a div with text", () => {
+    checkElementParity(<div>{'Text'}</div>);
+  });
+
+  describe("a div with blank text child", () => {
+    checkElementParity(<div>{''}</div>);
+  });
+
+  describe("renders a div with blank text children", () => {
+    checkElementParity(<div>{''}{''}{''}</div>);
+  });
+
+  describe("a div with whitespace children", () => {
+    checkElementParity(<div>{' '}{' '}{' '}</div>);
+  });
+
+  describe("a div with text sibling to a node", () => {
+    checkElementParity(<div>Text<span>More Text</span></div>);
+  });
+
+  describe("a non-standard element with text", () => {
+    checkElementParity(<nonstandard>Text</nonstandard>);
+  });
+
+  describe("a custom element with text", () => {
+    checkElementParity(<custom-element>Text</custom-element>);
+  });
+
+  describe("leading blank children with comments when there are multiple children", () => {
+    checkElementParity(<div>{''}foo</div>);
+  });
+
+  describe("trailing blank children with comments when there are multiple children", () => {
+    checkElementParity(<div>foo{''}</div>);
+  });
+
+  describe("an element with just one text child without comments", () => {
+    checkElementParity(<div>foo</div>);
+  });
+
+  describe("an element with two text children with comments", () => {
+    checkElementParity(<div>{'foo'}{'bar'}</div>);
+  });
+
+  describe("a div with multiple children elements separated by whitespace", () => {
+    checkElementParity(<div id="parent"><div id="child1" /> <div id="child2" /></div>);
+  });
+
+  describe("a div with a child element surrounded by whitespace", () => {
+    // eslint-disable-next-line no-multi-spaces
+    checkElementParity(<div id="parent">  <div id="child" />   </div>);
+  });
+
+});
+
+describe("elements with number children", () => {
+  describe("a number as single child", () => {
+    checkElementParity(<div>{3}</div>);
+  });
+
+  // zero is falsey, so it could look like no children if the code isn't careful.
+  describe("zero as single child", () => {
+    checkElementParity(<div>{0}</div>);
+  });
+
+  describe("an element with number and text children with comments", () => {
+    checkElementParity(<div>{'foo'}{40}</div>);
+  });
+});
+
+describe("null, false, and undefined children", () => {
+  describe("null single child as blank", () => {
+    checkElementParity(<div>{null}</div>);
+  });
+
+  describe("false single child as blank", () => {
+    checkElementParity(<div>{false}</div>);
+  });
+
+  describe("undefined single child as blank", () => {
+    checkElementParity(<div>{undefined}</div>);
+  });
+
+  describe("a null component children as empty", () => {
+    const NullComponent = () => null;
+    checkElementParity(<div><NullComponent /></div>);
+  });
+
+  describe("null children as blank", () => {
+    checkElementParity(<div>{null}foo</div>);
+  });
+
+  describe("false children as blank", () => {
+    checkElementParity(<div>{false}foo</div>);
+  });
+
+  describe("null and false children together as blank", () => {
+    checkElementParity(<div>{false}{null}foo{null}{false}</div>);
+  });
+
+  describe("only null and false children as blank", () => {
+    checkElementParity(<div>{false}{null}{null}{false}</div>);
+  });
+});
+
+describe("escaping >, <, and & in children", () => {
+  describe(">,<, and & in a single child", () => {
+    checkElementParity(<div>{'<span>Text&quot;</span>'}</div>);
+  });
+
+  describe(">,<, and & in multiple children", () => {
+    checkElementParity(<div>{'<span>Text1&quot;</span>'}{'<span>Text2&quot;</span>'}</div>);
   });
 });

--- a/spec/elements.js
+++ b/spec/elements.js
@@ -1,0 +1,71 @@
+import { default as React } from "react";
+
+import { checkElementParity } from "./_util";
+
+describe("elements with implicit namespaces", () => {
+  describe("an svg element", () => {
+    checkElementParity(<svg />);
+  });
+
+  describe("svg element with an xlink", () => {
+    checkElementParity(<svg><image xlinkHref="http://i.imgur.com/w7GCRPb.png" /></svg>);
+  });
+
+  describe("a math element", () => {
+    checkElementParity(<math />);
+  });
+});
+
+// specially wrapped components
+// (see the big switch near the beginning ofReactDOMComponent.mountComponent)
+describe("an img", () => {
+  checkElementParity(<img />);
+});
+
+describe("newline-eating elements", () => {
+  describe("a newline-eating tag with content not starting with \\n", () => {
+    checkElementParity(<pre>Hello</pre>);
+  });
+  describe("a newline-eating tag with content starting with \\n", () => {
+    checkElementParity(<pre>{'\nHello'}</pre>);
+  });
+  describe("a normal tag with content starting with \\n", () => {
+    checkElementParity(<div>{'\nHello'}</div>);
+  });
+});
+
+describe("different component implementations", () => {
+  describe("stateless components", () => {
+    const StatelessComponent = () => <div>foo</div>;
+    checkElementParity(<StatelessComponent />);
+  });
+
+  describe("React.createClass components", () => {
+    const RccComponent = React.createClass({ // eslint-disable-line react/prefer-es6-class
+      render () {
+        return <div>foo</div>;
+      }
+    });
+    checkElementParity(<RccComponent />);
+  });
+
+  describe("ES6 class components", () => {
+    class ClassComponent extends React.Component {
+      render () {
+        return <div>foo</div>;
+      }
+    }
+    checkElementParity(<ClassComponent />);
+  });
+
+  describe("factory components", () => {
+    const FactoryComponent = () => {
+      return {
+        render () {
+          return <div>foo</div>;
+        }
+      };
+    };
+    checkElementParity(<FactoryComponent />);
+  });
+});

--- a/spec/exec.js
+++ b/spec/exec.js
@@ -14,6 +14,7 @@ global.AssertionError = chai.AssertionError;
 global.Assertion = chai.Assertion;
 global.assert = chai.assert;
 
+require("./attributes");
 require("./cache");
 require("./children");
 require("./context");

--- a/spec/exec.js
+++ b/spec/exec.js
@@ -19,6 +19,7 @@ require("./cache");
 require("./children");
 require("./context");
 require("./deep-hierarchies");
+require("./elements");
 require("./lifecycle-methods");
 require("./special-cases");
 require("./template");

--- a/spec/lifecycle-methods.js
+++ b/spec/lifecycle-methods.js
@@ -2,6 +2,7 @@ import { default as React, Component } from "react";
 
 import { render } from "../src";
 
+import { checkElementParity } from "./_util";
 
 class C extends Component {
   constructor (...args) {
@@ -82,4 +83,17 @@ describe("lifecycle methods", () => {
       expect(html).to.equal("<div>set-again</div>");
     });
   });
+
+  describe("with a getInitialState call for createClass components", () => {
+    const InitalStateComponent = React.createClass({ // eslint-disable-line react/prefer-es6-class
+      getInitialState () {
+        return { text: "foo" };
+      },
+      render () {
+        return <div>{this.state.text}</div>;
+      }
+    });
+    checkElementParity(<InitalStateComponent />);
+  });
+
 });

--- a/spec/special-cases.js
+++ b/spec/special-cases.js
@@ -2,6 +2,7 @@ import { default as React } from "react";
 
 import { render } from "../src";
 
+import { checkElementParity } from "./_util";
 
 describe("special cases", () => {
   it("renders components that return null", () => {
@@ -12,4 +13,15 @@ describe("special cases", () => {
       expect(html).to.equal("<div></div>");
     });
   });
+
+  describe("a false component as empty", () => {
+    const FalseComponent = () => false;
+    checkElementParity(<FalseComponent />);
+  });
+
+  describe("a null component as empty", () => {
+    const NullComponent = () => null;
+    checkElementParity(<NullComponent />);
+  });
+
 });


### PR DESCRIPTION
Hey Rapscallion folks!

As I noted in one of the bug threads, I have a large set of SSR unit tests from my previous work on `react-dom-stream`, I'm currently trying to get them merged into react master. I thought it might help y'all to run some of them against Rapscallion.

I ran a small subset of the tests, just the ones that concentrate on how properties are turned into attributes, and I found a bunch of cases where Rapscallion diverges from `ReactDOMServer#renderToString`.

This PR includes 42 test cases, 23 of which currently produce different markup in Rapscallion than `ReactDOMServer#renderToString`. I don't really have the time to try to find and fix these bugs, but I hope that the failing tests will help you. 

If you do appreciate this, please let me know, as I can spend some time porting some of the other tests I have to Rapscallion. Cheers, and have a great day!