### PR TITLE
Copy over react's escapeTextContentForBrowser implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   "dependencies": {
     "adler-32": "^1.0.0",
     "bluebird": "^3.4.7",
-    "escape-html": "^1.0.3",
     "lodash": "^4.17.4"
   }
 }

--- a/spec/escape-html.js
+++ b/spec/escape-html.js
@@ -1,0 +1,14 @@
+import { checkParity, getRootNode } from "./_util";
+
+const code = `
+const FooBar = () => (
+  <div>{"<script type='' src=\\"\\"></script>"}</div>
+);
+
+return FooBar;
+`;
+
+describe("escape/encode html parity", () => {
+  const FooBar = getRootNode(code);
+  checkParity(FooBar, {});
+});

--- a/spec/exec.js
+++ b/spec/exec.js
@@ -21,4 +21,5 @@ require("./deep-hierarchies");
 require("./lifecycle-methods");
 require("./special-cases");
 require("./template");
+require("./escape-html");
 require("./styles");

--- a/src/render/escape-html.js
+++ b/src/render/escape-html.js
@@ -1,0 +1,124 @@
+/* eslint-disable */
+
+// Code copied from https://github.com/facebook/react/blob/d6e70586b77d4d52c4046b007b8a619e4463058c/src/renderers/dom/shared/escapeTextContentForBrowser.js
+
+/**
+ * Copyright 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * Based on the escape-html library, which is used under the MIT License below:
+ *
+ * Copyright (c) 2012-2013 TJ Holowaychuk
+ * Copyright (c) 2015 Andreas Lubbe
+ * Copyright (c) 2015 Tiancheng "Timothy" Gu
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * 'Software'), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @providesModule escapeTextContentForBrowser
+ */
+
+'use strict';
+
+// code copied and modified from escape-html
+/**
+ * Module variables.
+ * @private
+ */
+
+var matchHtmlRegExp = /["'&<>]/;
+
+/**
+ * Escape special characters in the given string of html.
+ *
+ * @param  {string} string The string to escape for inserting into HTML
+ * @return {string}
+ * @public
+ */
+
+function escapeHtml(string) {
+  var str = '' + string;
+  var match = matchHtmlRegExp.exec(str);
+
+  if (!match) {
+    return str;
+  }
+
+  var escape;
+  var html = '';
+  var index = 0;
+  var lastIndex = 0;
+
+  for (index = match.index; index < str.length; index++) {
+    switch (str.charCodeAt(index)) {
+      case 34: // "
+        escape = '&quot;';
+        break;
+      case 38: // &
+        escape = '&amp;';
+        break;
+      case 39: // '
+        escape = '&#x27;';  // modified from escape-html; used to be '&#39'
+        break;
+      case 60: // <
+        escape = '&lt;';
+        break;
+      case 62: // >
+        escape = '&gt;';
+        break;
+      default:
+        continue;
+    }
+
+    if (lastIndex !== index) {
+      html += str.substring(lastIndex, index);
+    }
+
+    lastIndex = index + 1;
+    html += escape;
+  }
+
+  return lastIndex !== index
+    ? html + str.substring(lastIndex, index)
+    : html;
+}
+// end code copied and modified from escape-html
+
+
+/**
+ * Escapes text to prevent scripting attacks.
+ *
+ * @param {*} text Text value to escape.
+ * @return {string} An escaped string.
+ */
+function escapeTextContentForBrowser(text) {
+  if (typeof text === 'boolean' || typeof text === 'number') {
+    // this shortcircuit helps perf for types that we know will never have
+    // special characters, especially given that this function is used often
+    // for numeric dom ids.
+    return '' + text;
+  }
+  return escapeHtml(text);
+}
+
+module.exports = escapeTextContentForBrowser;

--- a/src/render/traverse.js
+++ b/src/render/traverse.js
@@ -1,6 +1,6 @@
 const { getChildContext, getContext } = require("./context");
 const { syncSetState } = require("./state");
-const { htmlStringEscape } = require("./util");
+const htmlStringEscape = require("./escape-html");
 const renderAttrs = require("./attrs");
 
 const { REACT_ID } = require("../symbols");

--- a/src/render/util.js
+++ b/src/render/util.js
@@ -1,12 +1,4 @@
-const escapeHtml = require("escape-html");
 const { kebabCase } = require("lodash");
-
-const htmlStringEscape = str => {
-  if (typeof str === "boolean" || typeof str === "number") {
-    return String(str);
-  }
-  return escapeHtml(str);
-};
 
 const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
 /**
@@ -22,7 +14,6 @@ const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
 const hyphenateStyleName = (string) => kebabCase(string).replace(/^ms-/, "-ms-");
 
 module.exports = {
-  htmlStringEscape,
   hasOwn,
   hyphenateStyleName
 };

--- a/src/transform/server.js
+++ b/src/transform/server.js
@@ -1,7 +1,7 @@
 const t = require("babel-types");
 const { flatten } = require("lodash");
 
-const { htmlStringEscape } = require("../render/util");
+const htmlStringEscape = require("../render/escape-html");
 const { REACT_ID } = require("../symbols");
 
 


### PR DESCRIPTION
I've copied the entire file over, including the copyright headers, and disabled linting for the file.

Resolves #57 