### PR TITLE
set component props and context after constructor is called

### DIFF
--- a/spec/special-cases.js
+++ b/spec/special-cases.js
@@ -1,4 +1,4 @@
-import { default as React } from "react";
+import { default as React, Component } from "react";
 
 import { render } from "../src";
 
@@ -10,6 +10,19 @@ describe("special cases", () => {
 
     return render(<Parent />).includeDataReactAttrs(false).toPromise().then(html => {
       expect(html).to.equal("<div></div>");
+    });
+  });
+  it("renders components that don't pass constructor arguments to super", () => {
+    class C extends Component {
+      constructor () {
+        super();
+      }
+      render () {
+        return <div>{this.props.foo}</div>;
+      }
+    }
+    return render(<C foo="bar"/>).includeDataReactAttrs(false).toPromise().then(html => {
+      expect(html).to.equal("<div>bar</div>");
     });
   });
 });

--- a/src/render/traverse.js
+++ b/src/render/traverse.js
@@ -91,6 +91,8 @@ function evalComponent (seq, node, context) {
 
   // eslint-disable-next-line new-cap
   const instance = new node.type(node.props, componentContext);
+  instance.props = node.props;
+  instance.context = componentContext;
 
   if (typeof instance.componentWillMount === "function") {
     instance.setState = syncSetState;


### PR DESCRIPTION
The following will work fine with normal react rendering because [React sets props/context on components after the constructor is called.](https://discuss.reactjs.org/t/should-we-include-the-props-parameter-to-class-constructors-when-declaring-components-using-es6-classes/2781/4)
```js
class extends Component {
    constructor() {
        super();
    }
    ...
}
```
```js
<Component key="value"/>
```

However when rendering with rapscallion the props/context aren't ever set on the component. This PR should make it work the way React does.