### PR TITLE
only export lib

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,1 @@
-try {
-  module.exports = require("./lib");
-} catch (err) {
-  module.exports = require("./src");
-}
+module.exports = require("./lib");


### PR DESCRIPTION
Tests seem to test src directly, and src is not included in the published files so I'm not sure what the original intent behind this was. Perhaps its safe to remove?