### PR TITLE
Discrepancies w/React Rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babel-plugin-transform-react-jsx": "^6.22.0",
     "babel-preset-latest": "^6.22.0",
     "chai": "^3.5.0",
+    "cheerio": "^0.22.0",
     "eslint": "2.10.2",
     "eslint-config-formidable": "^2.0.1",
     "eslint-plugin-filenames": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "babel-plugin-transform-react-jsx": "^6.22.0",
     "babel-preset-latest": "^6.22.0",
     "chai": "^3.5.0",
-    "cheerio": "^0.22.0",
     "eslint": "2.10.2",
     "eslint-config-formidable": "^2.0.1",
     "eslint-plugin-filenames": "^1.1.0",

--- a/spec/attrs.js
+++ b/spec/attrs.js
@@ -39,28 +39,47 @@ describe.only("attributes", () => {
     });
   });
   it("include those not tracked by React", () => {
-    expect(renderAttrs({ "data-track": "click.something.somewhere" })).to.equal(" data-track=\"click.something.somewhere\"");
+    expect(renderAttrs({ "data-track": "click.something.somewhere" }))
+    .to.equal(" data-track=\"click.something.somewhere\"");
   });
-  xit("that must be included are always included", () => {
-    throw 'test not implemented';
+  it("are HTML encoded", () => {
+    expect(renderAttrs({ href: "/?this=that&foo=bar" }))
+    .to.equal(" href=\"/?this=that&amp;foo=bar\"");
   });
-  xdescribe("expecting numbers", () => {
+  it("that must be included are always included", () => {
+    expect(renderAttrs({ checked: false })).to.equal(" checked=\"false\"");
+    expect(renderAttrs({ checked: true })).to.equal(" checked=\"true\"");
+  });
+  describe("expecting numbers", () => {
     it("are absent when their value is NaN", () => {
-      throw 'test not implemented';
+      expect(renderAttrs({ rowSpan: NaN })).to.equal("");
     });
     it("are present when their value is a number", () => {
-      throw 'test not implemented';
+      expect(renderAttrs({ rowSpan: 0 })).to.equal(" rowspan=\"0\"");
     });
-  })
-  xdescribe("expecting positive numbers", () => {
+  });
+  describe("expecting positive numbers", () => {
     it("are absent when their value is < 1", () => {
-      throw 'test not implemented';
+      expect(renderAttrs({ cols: 0 })).to.equal("");
     });
     it("are present when their value is >= 1", () => {
-      throw 'test not implemented';
+      expect(renderAttrs({ cols: 1 })).to.equal(" cols=\"1\"");
+      expect(renderAttrs({ cols: 2 })).to.equal(" cols=\"2\"");
     });
-  })
-  xit("overloaded boolean value?", () => {
-    throw 'test not implemented';
+  });
+  describe("expecting overloaded boolean values", () => {
+    it("include strings when true", () => {
+      expect(renderAttrs({ download: true })).to.equal(" download=\"\"");
+    });
+    it("are absent when false, undefined, or null", () => {
+      expect(renderAttrs({ download: false })).to.equal("");
+      expect(renderAttrs({ download: undefined })).to.equal("");
+      expect(renderAttrs({ download: null })).to.equal("");
+    });
+    it("include strings when 0 or truthy", () => {
+      expect(renderAttrs({ download: 0 })).to.equal(" download=\"0\"");
+      expect(renderAttrs({ download: 1 })).to.equal(" download=\"1\"");
+      expect(renderAttrs({ download: "https://www.shutterstock.com?this=that&foo=bar" })).to.equal(" download=\"https://www.shutterstock.com?this=that&foo=bar\"");
+    });
   });
 });

--- a/spec/attrs.js
+++ b/spec/attrs.js
@@ -1,6 +1,6 @@
 const renderAttrs = require("../src/render/attrs");
 
-describe.only("attributes", () => {
+describe("attributes", () => {
   it("do not include children", () => {
     expect(renderAttrs({ children: "value" })).to.equal("");
   });

--- a/spec/attrs.js
+++ b/spec/attrs.js
@@ -1,0 +1,66 @@
+const renderAttrs = require("../src/render/attrs");
+
+describe.only("attributes", () => {
+  it("do not include children", () => {
+    expect(renderAttrs({ children: "value" })).to.equal("");
+  });
+  it("do not include dangerouslySetInnerHTML", () => {
+    expect(renderAttrs({ dangerouslySetInnerHTML: "value" })).to.equal("");
+  });
+  it("do not include null values", () => {
+    expect(renderAttrs({ id: null })).to.equal("");
+  });
+  it("do not include undefined values", () => {
+    expect(renderAttrs({ id: undefined })).to.equal("");
+  });
+  it("include empty string values", () => {
+    expect(renderAttrs({ id: "" })).to.equal(" id=\"\"");
+  });
+  it("do not include function values", () => {
+    expect(renderAttrs({ onclick: () => {} })).to.equal("");
+  });
+  describe("expecting booleans", () => {
+    it("are valueless when true", () => {
+      expect(renderAttrs({ disabled: true })).to.equal(" disabled");
+    });
+    it("are absent when falsy", () => {
+      expect(renderAttrs({ disabled: false })).to.equal("");
+    });
+  });
+  describe("expecting objects", () => {
+    it("are absent when not objects", () => {
+      expect(renderAttrs({ style: "value" })).to.equal("");
+    });
+    it("are absent when they have no keys", () => {
+      expect(renderAttrs({ style: {} })).to.equal("");
+    });
+    it("include key/value pairs when they have keys", () => {
+      expect(renderAttrs({ style: { display: "none " } })).to.equal(" style=\"display:none;\"");
+    });
+  });
+  it("include those not tracked by React", () => {
+    expect(renderAttrs({ "data-track": "click.something.somewhere" })).to.equal(" data-track=\"click.something.somewhere\"");
+  });
+  xit("that must be included are always included", () => {
+    throw 'test not implemented';
+  });
+  xdescribe("expecting numbers", () => {
+    it("are absent when their value is NaN", () => {
+      throw 'test not implemented';
+    });
+    it("are present when their value is a number", () => {
+      throw 'test not implemented';
+    });
+  })
+  xdescribe("expecting positive numbers", () => {
+    it("are absent when their value is < 1", () => {
+      throw 'test not implemented';
+    });
+    it("are present when their value is >= 1", () => {
+      throw 'test not implemented';
+    });
+  })
+  xit("overloaded boolean value?", () => {
+    throw 'test not implemented';
+  });
+});

--- a/spec/exec.js
+++ b/spec/exec.js
@@ -2,6 +2,9 @@ Error.stackTraceLimit = Infinity;
 
 require("babel-core/register");
 
+// initializes react-dom/lib/DOMProperty for tests
+require("react-dom/server");
+
 const chai = require("chai");
 const sinonChai = require("sinon-chai");
 global.sinon = require("sinon");

--- a/spec/exec.js
+++ b/spec/exec.js
@@ -23,3 +23,4 @@ require("./special-cases");
 require("./template");
 require("./escape-html");
 require("./styles");
+require("./attrs");

--- a/spec/special-cases.js
+++ b/spec/special-cases.js
@@ -1,5 +1,4 @@
 import { default as React, Component } from "react";
-import cheerio from "cheerio";
 
 import { render } from "../src";
 
@@ -29,13 +28,11 @@ describe("special cases", () => {
   it("renders text comments for children with siblings", () => {
     const TextWithSiblingsComponent = () => <div id="root"><div>child 1</div>child 2</div>;
 
-    const expected =
-      "<div data-reactid=\"2\">child 1</div><!-- react-text: 3 -->child 2<!-- /react-text -->";
+    // eslint-disable-next-line max-len
+    const expected = "<div id=\"root\" data-reactroot=\"\" data-reactid=\"1\" data-react-checksum=\"-1855509454\"><div data-reactid=\"2\">child 1</div><!-- react-text: 3 -->child 2<!-- /react-text --></div>";
 
     return render(<TextWithSiblingsComponent />)
       .toPromise()
-      .then(cheerio.load)
-      .then($ => $("#root").html())
       .then(html => expect(html).to.equal(expected));
   });
   it("renders components that don't pass constructor arguments to super", () => {

--- a/spec/special-cases.js
+++ b/spec/special-cases.js
@@ -1,4 +1,5 @@
 import { default as React, Component } from "react";
+import cheerio from 'cheerio';
 
 import { render } from "../src";
 
@@ -9,7 +10,21 @@ describe("special cases", () => {
     const Parent = () => <div><NullComponent /></div>;
 
     return render(<Parent />).includeDataReactAttrs(false).toPromise().then(html => {
-      expect(html).to.equal("<div><!-- react-empty --></div>");
+      expect(html).to.equal("<div></div>");
+    });
+  });
+  it("renders empty comments for components that return null", () => {
+    const NullComponent = () => null;
+
+    return render(<NullComponent />).toPromise().then(cheerio.load).then($ => {
+      expect($.html()).to.equal("<!-- react-empty: 1 -->");
+    });
+  });
+  it("does not renders text comments for single children", () => {
+    const TextComponent = () => "some text";
+
+    return render(<TextComponent />).toPromise().then(cheerio.load).then($ => {
+      expect($.html()).to.equal("some text");
     });
   });
   it("renders components that don't pass constructor arguments to super", () => {

--- a/spec/special-cases.js
+++ b/spec/special-cases.js
@@ -69,6 +69,7 @@ describe("special cases", () => {
       .then(html => expect(html).to.equal("<a></a>"));
   });
   it("renders true attributes as valueless", () => {
+    // eslint-disable-next-line react/jsx-boolean-value
     const ValuelessAttribute = () => <a disabled={true} />;
 
     return render(<ValuelessAttribute />)

--- a/spec/special-cases.js
+++ b/spec/special-cases.js
@@ -1,5 +1,5 @@
 import { default as React, Component } from "react";
-import cheerio from 'cheerio';
+import cheerio from "cheerio";
 
 import { render } from "../src";
 

--- a/spec/special-cases.js
+++ b/spec/special-cases.js
@@ -38,37 +38,6 @@ describe("special cases", () => {
       .then($ => $("#root").html())
       .then(html => expect(html).to.equal(expected));
   });
-  // it("does not render non-number falsy attributes", () => {
-  //   const ComponentWithFalsyAttribute = () => (
-  //     <div>
-  //       <a disabled={false} />
-  //       <a disabled={null} />
-  //       <a disabled={undefined} />
-  //     </div>
-  //   );
-  //
-  //   return render(<ComponentWithFalsyAttribute />)
-  //     .includeDataReactAttrs(false)
-  //     .toPromise()
-  //     .then(html => expect(html).to.equal("<div><a></a><a></a><a></a></div>"));
-  // });
-  // it("renders zero attributes as a string", () => {
-  //   const ComponentWithZeroAttribute = () => <a disabled={0} />;
-  //
-  //   return render(<ComponentWithZeroAttribute />)
-  //     .includeDataReactAttrs(false)
-  //     .toPromise()
-  //     .then(html => expect(html).to.equal("<a></a>"));
-  // });
-  // it("renders true attributes as valueless", () => {
-  //   // eslint-disable-next-line react/jsx-boolean-value
-  //   const ValuelessAttribute = () => <a disabled={true} />;
-  //
-  //   return render(<ValuelessAttribute />)
-  //     .includeDataReactAttrs(false)
-  //     .toPromise()
-  //     .then(html => expect(html).to.equal("<a disabled></a>"));
-  // });
   it("renders components that don't pass constructor arguments to super", () => {
     class C extends Component {
       constructor () {
@@ -82,13 +51,4 @@ describe("special cases", () => {
       expect(html).to.equal("<div>bar</div>");
     });
   });
-  // it("renders true aria attributes", () => {
-  //   // eslint-disable-next-line react/jsx-boolean-value
-  //   const ComponentWithAriaAttribute = () => <a aria-expanded={true} />;
-  //
-  //   return render(<ComponentWithAriaAttribute />)
-  //     .includeDataReactAttrs(false)
-  //     .toPromise()
-  //     .then(html => expect(html).to.equal("<a aria-expanded=\"true\"></a>"));
-  // });
 });

--- a/spec/special-cases.js
+++ b/spec/special-cases.js
@@ -9,7 +9,7 @@ describe("special cases", () => {
     const Parent = () => <div><NullComponent /></div>;
 
     return render(<Parent />).includeDataReactAttrs(false).toPromise().then(html => {
-      expect(html).to.equal("<div></div>");
+      expect(html).to.equal("<div><!-- react-empty --></div>");
     });
   });
   it("renders components that don't pass constructor arguments to super", () => {

--- a/spec/special-cases.js
+++ b/spec/special-cases.js
@@ -38,37 +38,37 @@ describe("special cases", () => {
       .then($ => $("#root").html())
       .then(html => expect(html).to.equal(expected));
   });
-  it("does not render non-number falsy attributes", () => {
-    const ComponentWithFalsyAttribute = () => (
-      <div>
-        <a disabled={false} />
-        <a disabled={null} />
-        <a disabled={undefined} />
-      </div>
-    );
-
-    return render(<ComponentWithFalsyAttribute />)
-      .includeDataReactAttrs(false)
-      .toPromise()
-      .then(html => expect(html).to.equal("<div><a></a><a></a><a></a></div>"));
-  });
-  it("renders zero attributes as a string", () => {
-    const ComponentWithZeroAttribute = () => <a disabled={0} />;
-
-    return render(<ComponentWithZeroAttribute />)
-      .includeDataReactAttrs(false)
-      .toPromise()
-      .then(html => expect(html).to.equal("<a></a>"));
-  });
-  it("renders true attributes as valueless", () => {
-    // eslint-disable-next-line react/jsx-boolean-value
-    const ValuelessAttribute = () => <a disabled={true} />;
-
-    return render(<ValuelessAttribute />)
-      .includeDataReactAttrs(false)
-      .toPromise()
-      .then(html => expect(html).to.equal("<a disabled></a>"));
-  });
+  // it("does not render non-number falsy attributes", () => {
+  //   const ComponentWithFalsyAttribute = () => (
+  //     <div>
+  //       <a disabled={false} />
+  //       <a disabled={null} />
+  //       <a disabled={undefined} />
+  //     </div>
+  //   );
+  //
+  //   return render(<ComponentWithFalsyAttribute />)
+  //     .includeDataReactAttrs(false)
+  //     .toPromise()
+  //     .then(html => expect(html).to.equal("<div><a></a><a></a><a></a></div>"));
+  // });
+  // it("renders zero attributes as a string", () => {
+  //   const ComponentWithZeroAttribute = () => <a disabled={0} />;
+  //
+  //   return render(<ComponentWithZeroAttribute />)
+  //     .includeDataReactAttrs(false)
+  //     .toPromise()
+  //     .then(html => expect(html).to.equal("<a></a>"));
+  // });
+  // it("renders true attributes as valueless", () => {
+  //   // eslint-disable-next-line react/jsx-boolean-value
+  //   const ValuelessAttribute = () => <a disabled={true} />;
+  //
+  //   return render(<ValuelessAttribute />)
+  //     .includeDataReactAttrs(false)
+  //     .toPromise()
+  //     .then(html => expect(html).to.equal("<a disabled></a>"));
+  // });
   it("renders components that don't pass constructor arguments to super", () => {
     class C extends Component {
       constructor () {
@@ -82,13 +82,13 @@ describe("special cases", () => {
       expect(html).to.equal("<div>bar</div>");
     });
   });
-  it("renders true aria attributes", () => {
-    // eslint-disable-next-line react/jsx-boolean-value
-    const ComponentWithAriaAttribute = () => <a aria-expanded={true} />;
-
-    return render(<ComponentWithAriaAttribute />)
-      .includeDataReactAttrs(false)
-      .toPromise()
-      .then(html => expect(html).to.equal("<a aria-expanded=\"true\"></a>"));
-  });
+  // it("renders true aria attributes", () => {
+  //   // eslint-disable-next-line react/jsx-boolean-value
+  //   const ComponentWithAriaAttribute = () => <a aria-expanded={true} />;
+  //
+  //   return render(<ComponentWithAriaAttribute />)
+  //     .includeDataReactAttrs(false)
+  //     .toPromise()
+  //     .then(html => expect(html).to.equal("<a aria-expanded=\"true\"></a>"));
+  // });
 });

--- a/spec/special-cases.js
+++ b/spec/special-cases.js
@@ -18,16 +18,12 @@ describe("special cases", () => {
 
     return render(<NullComponent />)
       .toPromise()
-      .then(cheerio.load)
-      .then($ => $.html())
       .then(html => expect(html).to.equal("<!-- react-empty: 1 -->"));
   });
   it("does not render text comments for children without siblings", () => {
     const TextComponent = () => "some text";
 
     return render(<TextComponent />).toPromise()
-      .then(cheerio.load)
-      .then($ => $.html())
       .then(html => expect(html).to.equal("some text"));
   });
   it("renders text comments for children with siblings", () => {
@@ -54,18 +50,14 @@ describe("special cases", () => {
     return render(<ComponentWithFalsyAttribute />)
       .includeDataReactAttrs(false)
       .toPromise()
-      .then(cheerio.load)
-      .then($ => $.html())
       .then(html => expect(html).to.equal("<div><a></a><a></a><a></a></div>"));
   });
   it("renders zero attributes as a string", () => {
-    const ComponentWithZeroAttribute = () => <a disabled={false} />;
+    const ComponentWithZeroAttribute = () => <a disabled={0} />;
 
     return render(<ComponentWithZeroAttribute />)
       .includeDataReactAttrs(false)
       .toPromise()
-      .then(cheerio.load)
-      .then($ => $.html())
       .then(html => expect(html).to.equal("<a></a>"));
   });
   it("renders true attributes as valueless", () => {
@@ -75,8 +67,6 @@ describe("special cases", () => {
     return render(<ValuelessAttribute />)
       .includeDataReactAttrs(false)
       .toPromise()
-      .then(cheerio.load)
-      .then($ => $.html())
       .then(html => expect(html).to.equal("<a disabled></a>"));
   });
   it("renders components that don't pass constructor arguments to super", () => {
@@ -91,5 +81,14 @@ describe("special cases", () => {
     return render(<C foo="bar"/>).includeDataReactAttrs(false).toPromise().then(html => {
       expect(html).to.equal("<div>bar</div>");
     });
+  });
+  it("renders true aria attributes", () => {
+    // eslint-disable-next-line react/jsx-boolean-value
+    const ComponentWithAriaAttribute = () => <a aria-expanded={true} />;
+
+    return render(<ComponentWithAriaAttribute />)
+      .includeDataReactAttrs(false)
+      .toPromise()
+      .then(html => expect(html).to.equal("<a aria-expanded=\"true\"></a>"));
   });
 });

--- a/src/render/attrs/index.js
+++ b/src/render/attrs/index.js
@@ -30,14 +30,17 @@ function stringifyAttr (attr, value) {
   }
 
   if (
-    !info.mustUseProperty &&
-    info.hasBooleanValue ||
-    (info.hasOverloadedBooleanValue && value === true)
+    !info.mustUseProperty && (
+      info.hasBooleanValue ||
+      (info.hasOverloadedBooleanValue && value === true)
+    )
   ) {
     finalValue = "";
+  } else {
+    finalValue = `="${finalValue}"`;
   }
 
-  return `${finalAttr}="${finalValue}"`;
+  return `${finalAttr}${finalValue}`;
 }
 
 /**

--- a/src/render/attrs/index.js
+++ b/src/render/attrs/index.js
@@ -7,9 +7,11 @@ const SVGDOMPropertyConfig = require("react-dom/lib/SVGDOMPropertyConfig");
 const { renderStyleAttribute } = require("./style");
 const escapeHtml = require("../escape-html");
 
-DOMProperty.injection.injectDOMPropertyConfig(ARIADOMPropertyConfig);
-DOMProperty.injection.injectDOMPropertyConfig(HTMLDOMPropertyConfig);
-DOMProperty.injection.injectDOMPropertyConfig(SVGDOMPropertyConfig);
+if (Object.keys(DOMProperty.properties).length === 0) {
+  DOMProperty.injection.injectDOMPropertyConfig(ARIADOMPropertyConfig);
+  DOMProperty.injection.injectDOMPropertyConfig(HTMLDOMPropertyConfig);
+  DOMProperty.injection.injectDOMPropertyConfig(SVGDOMPropertyConfig);
+}
 
 const attrsNotToRender = {
   children: true,

--- a/src/render/attrs/index.js
+++ b/src/render/attrs/index.js
@@ -28,13 +28,24 @@ function renderAttrs (attrs) {
       let attrVal = attrs[attrKey];
 
       if (
-        !attrVal || isFunction(attrVal) ||
-        !(Object.keys(attrVal).length > 0)
-      ) { continue; }
+        attrVal === undefined ||
+        attrVal === null ||
+        attrVal === false ||
+        isFunction(attrVal) ||
+        (
+          typeof attrVal === "object" &&
+          !(Object.keys(attrVal).length > 0)
+        )
+      ) {
+        continue;
+      }
 
       attrKey = transformAttrKey(attrKey);
-
-      if (attrVal === true) {
+      if (
+        attrVal === true ||
+        attrVal === undefined ||
+        attrVal === null
+      ) {
         attrVal = "";
       } else if (attrKey === "style" && typeof attrVal === "object") {
         attrVal = `="${renderStyleAttribute(attrVal)}"`;

--- a/src/render/attrs/index.js
+++ b/src/render/attrs/index.js
@@ -10,6 +10,11 @@ const attrsNotToRender = {
   dangerouslySetInnerHTML: true
 };
 
+const attrsWithExplicitBoolValue = [
+  "aria-expanded",
+  "aria-haspopup"
+];
+
 /**
  * Render an object of key/value pairs into their HTML attribute equivalent.
  *
@@ -26,11 +31,15 @@ function renderAttrs (attrs) {
       !attrsNotToRender[attrKey]
     ) {
       let attrVal = attrs[attrKey];
+      const explicitBooleanValue = attrsWithExplicitBoolValue.includes(attrKey);
 
       if (
         attrVal === undefined ||
         attrVal === null ||
-        attrVal === false ||
+        (
+          attrVal === false &&
+          !(explicitBooleanValue)
+        ) ||
         isFunction(attrVal) ||
         (
           typeof attrVal === "object" &&
@@ -42,7 +51,10 @@ function renderAttrs (attrs) {
 
       attrKey = transformAttrKey(attrKey);
       if (
-        attrVal === true ||
+        (
+          attrVal === true &&
+          !(explicitBooleanValue)
+        ) ||
         attrVal === undefined ||
         attrVal === null
       ) {

--- a/src/render/attrs/index.js
+++ b/src/render/attrs/index.js
@@ -7,11 +7,9 @@ const SVGDOMPropertyConfig = require("react-dom/lib/SVGDOMPropertyConfig");
 const { renderStyleAttribute } = require("./style");
 const escapeHtml = require("../escape-html");
 
-if (!(Object.keys(DOMProperty.properties).length)) {
-  DOMProperty.injection.injectDOMPropertyConfig(ARIADOMPropertyConfig);
-  DOMProperty.injection.injectDOMPropertyConfig(HTMLDOMPropertyConfig);
-  DOMProperty.injection.injectDOMPropertyConfig(SVGDOMPropertyConfig);
-}
+DOMProperty.injection.injectDOMPropertyConfig(ARIADOMPropertyConfig);
+DOMProperty.injection.injectDOMPropertyConfig(HTMLDOMPropertyConfig);
+DOMProperty.injection.injectDOMPropertyConfig(SVGDOMPropertyConfig);
 
 const attrsNotToRender = {
   children: true,

--- a/src/render/attrs/index.js
+++ b/src/render/attrs/index.js
@@ -15,6 +15,37 @@ const attrsWithExplicitBoolValue = [
   "aria-haspopup"
 ];
 
+function shouldSkipRender (attrVal, isExplicitBoolValue) {
+  return (
+    attrVal === undefined ||
+    attrVal === null ||
+    (
+      attrVal === false &&
+      !(isExplicitBoolValue)
+    ) ||
+    isFunction(attrVal) ||
+    (
+      typeof attrVal === "object" &&
+      !(Object.keys(attrVal).length > 0)
+    )
+  );
+}
+
+function isValuelessAttribute (attrVal, isExplicitBoolValue) {
+  return (
+    (
+      attrVal === true &&
+      !(isExplicitBoolValue)
+    ) ||
+    attrVal === undefined ||
+    attrVal === null
+  );
+}
+
+function isStyleAttribute (attrKey, attrVal) {
+  return attrKey === "style" && typeof attrVal === "object";
+}
+
 /**
  * Render an object of key/value pairs into their HTML attribute equivalent.
  *
@@ -31,35 +62,17 @@ function renderAttrs (attrs) {
       !attrsNotToRender[attrKey]
     ) {
       let attrVal = attrs[attrKey];
-      const explicitBooleanValue = attrsWithExplicitBoolValue.includes(attrKey);
+      const isExplicitBoolValue = attrsWithExplicitBoolValue.includes(attrKey);
 
-      if (
-        attrVal === undefined ||
-        attrVal === null ||
-        (
-          attrVal === false &&
-          !(explicitBooleanValue)
-        ) ||
-        isFunction(attrVal) ||
-        (
-          typeof attrVal === "object" &&
-          !(Object.keys(attrVal).length > 0)
-        )
-      ) {
+      if (shouldSkipRender(attrVal, isExplicitBoolValue)) {
         continue;
       }
 
       attrKey = transformAttrKey(attrKey);
-      if (
-        (
-          attrVal === true &&
-          !(explicitBooleanValue)
-        ) ||
-        attrVal === undefined ||
-        attrVal === null
-      ) {
+
+      if (isValuelessAttribute(attrVal, isExplicitBoolValue)) {
         attrVal = "";
-      } else if (attrKey === "style" && typeof attrVal === "object") {
+      } else if (isStyleAttribute(attrKey, attrVal)) {
         attrVal = `="${renderStyleAttribute(attrVal)}"`;
       } else if (typeof attrVal === "string") {
         attrVal = `="${htmlStringEscape(attrVal)}"`;

--- a/src/render/attrs/index.js
+++ b/src/render/attrs/index.js
@@ -10,10 +10,10 @@ const attrsNotToRender = {
   dangerouslySetInnerHTML: true
 };
 
-const attrsWithExplicitBoolValue = [
-  "aria-expanded",
-  "aria-haspopup"
-];
+const attrsWithExplicitBoolValue = {
+  "aria-expanded": true,
+  "aria-haspopup": true
+};
 
 function shouldSkipRender (attrVal, isExplicitBoolValue) {
   return (
@@ -62,7 +62,7 @@ function renderAttrs (attrs) {
       !attrsNotToRender[attrKey]
     ) {
       let attrVal = attrs[attrKey];
-      const isExplicitBoolValue = attrsWithExplicitBoolValue.includes(attrKey);
+      const isExplicitBoolValue = !!attrsWithExplicitBoolValue[attrKey];
 
       if (shouldSkipRender(attrVal, isExplicitBoolValue)) {
         continue;

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -4,7 +4,11 @@ const { getRootContext } = require("./context");
 
 function render (seq, node, rootContext) {
   rootContext = rootContext || getRootContext();
-  traverse(seq, node, rootContext);
+  traverse({
+    seq,
+    node,
+    context: rootContext
+  });
   return seq;
 }
 

--- a/src/render/traverse.js
+++ b/src/render/traverse.js
@@ -3,7 +3,12 @@ const { syncSetState } = require("./state");
 const htmlStringEscape = require("./escape-html");
 const renderAttrs = require("./attrs");
 
-const { REACT_ID } = require("../symbols");
+const {
+  REACT_EMPTY,
+  REACT_ID,
+  REACT_TEXT_START,
+  REACT_TEXT_END
+} = require("../symbols");
 
 const omittedCloseTags = {
   "area": true,
@@ -166,12 +171,21 @@ function evalPreRendered (seq, node, context) {
  */
 function traverse (seq, node, context) {
   // A Component's render function might return `null`.
-  if (!node) { return; }
+  if (node === undefined || node === null) {
+    seq.emit(() => REACT_EMPTY);
+    return;
+  }
+
+  if (node === false) {
+    return;
+  }
 
   switch (typeof node) {
   case "string": {
     // Text node.
+    seq.emit(() => REACT_TEXT_START);
     seq.emit(() => htmlStringEscape(node));
+    seq.emit(() => REACT_TEXT_END);
     return;
   }
   case "number": {

--- a/src/render/traverse.js
+++ b/src/render/traverse.js
@@ -34,7 +34,7 @@ function renderChildrenArray (seq, children, context) {
     if (child instanceof Array) {
       renderChildrenArray(seq, child, context);
     } else {
-      traverse(seq, child, context);
+      traverse(seq, child, context, children.length);
     }
   }
 }
@@ -66,7 +66,7 @@ function renderNode (seq, node, context) {
   if (node.props.dangerouslySetInnerHTML) {
     seq.emit(() => node.props.dangerouslySetInnerHTML.__html || "");
   } else {
-    seq.delegate(() => renderChildren(seq, node.props.children, context));
+    seq.delegate(() => renderChildren(seq, node.props.children, context, node));
   }
   if (!omittedCloseTags[node.type]) {
     seq.emit(() => `</${node.type}>`);
@@ -169,7 +169,7 @@ function evalPreRendered (seq, node, context) {
  *
  * @return     {undefined}          No return value.
  */
-function traverse (seq, node, context) {
+function traverse (seq, node, context, numChildren) {
   // A Component's render function might return `null`.
   if (node === undefined || node === null) {
     seq.emit(() => REACT_EMPTY);
@@ -183,9 +183,13 @@ function traverse (seq, node, context) {
   switch (typeof node) {
   case "string": {
     // Text node.
-    seq.emit(() => REACT_TEXT_START);
+    if (numChildren) {
+      seq.emit(() => REACT_TEXT_START);
+    }
     seq.emit(() => htmlStringEscape(node));
-    seq.emit(() => REACT_TEXT_END);
+    if (numChildren) {
+      seq.emit(() => REACT_TEXT_END);
+    }
     return;
   }
   case "number": {

--- a/src/render/traverse.js
+++ b/src/render/traverse.js
@@ -170,8 +170,12 @@ function evalPreRendered (seq, node, context) {
  * @return     {undefined}          No return value.
  */
 function traverse (seq, node, context, numChildren) {
+  if (node === undefined) {
+    return;
+  }
+
   // A Component's render function might return `null`.
-  if (node === undefined || node === null) {
+  if (node === null) {
     seq.emit(() => REACT_EMPTY);
     return;
   }
@@ -180,20 +184,31 @@ function traverse (seq, node, context, numChildren) {
     return;
   }
 
+  const hasSiblings = !!numChildren;
+
   switch (typeof node) {
   case "string": {
+
     // Text node.
-    if (numChildren) {
+    if (hasSiblings) {
       seq.emit(() => REACT_TEXT_START);
     }
     seq.emit(() => htmlStringEscape(node));
-    if (numChildren) {
+    if (hasSiblings) {
       seq.emit(() => REACT_TEXT_END);
     }
+
     return;
   }
   case "number": {
+    if (hasSiblings) {
+      seq.emit(() => REACT_TEXT_START);
+    }
     seq.emit(() => node.toString());
+    if (hasSiblings) {
+      seq.emit(() => REACT_TEXT_END);
+    }
+
     return;
   }
   case "object": {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -36,38 +36,71 @@ class Renderer {
     render(seq || this.sequence, this.vdomNode);
   }
 
+  _rootVal () {
+    let val;
+
+    if (this.dataReactAttrs) {
+      val = this.reactIdIdx === REACT_ID_START ?
+        ` data-reactroot="" data-reactid="${this.reactIdIdx}"` :
+        ` data-reactid="${this.reactIdIdx}"`;
+
+      this.reactIdIdx++;
+
+      return val;
+    }
+
+    return val;
+  }
+
+  _emptyVal () {
+    let val;
+
+    if (this.dataReactAttrs) {
+      val = `<!-- react-empty: ${this.reactIdIdx} -->`;
+
+      this.reactIdIdx++;
+    }
+
+    return val;
+  }
+
+  _textStart () {
+    let val;
+
+    if (this.dataReactAttrs) {
+      val = `<!-- react-text: ${this.reactIdIdx} -->`;
+
+      this.reactIdIdx++;
+    }
+
+    return val;
+  }
+
+  _textEnd () {
+    let val;
+
+    if (this.dataReactAttrs) {
+      val = "<!-- /react-text -->";
+    }
+
+    return val;
+  }
+
   _next () {
     let nextVal = this.sequence.next();
 
     if (nextVal === REACT_ID) {
-      if (this.dataReactAttrs) {
-        nextVal = this.reactIdIdx === REACT_ID_START ?
-          ` data-reactroot="" data-reactid="${this.reactIdIdx}"` :
-          ` data-reactid="${this.reactIdIdx}"`;
-        this.reactIdIdx++;
-      } else {
-        return "";
-      }
+      nextVal = this._rootVal();
     } else if (nextVal === REACT_EMPTY) {
-      if (this.dataReactAttrs) {
-        nextVal = `<!-- react-empty: ${this.reactIdIdx} -->`;
-        this.reactIdIdx++;
-      } else {
-        return "";
-      }
+      nextVal = this._emptyVal();
     } else if (nextVal === REACT_TEXT_START) {
-      if (this.dataReactAttrs) {
-        nextVal = `<!-- react-text: ${this.reactIdIdx} -->`;
-        this.reactIdIdx++;
-      } else {
-        return "";
-      }
+      nextVal = this._textStart();
     } else if (nextVal === REACT_TEXT_END) {
-      if (this.dataReactAttrs) {
-        nextVal = "<!-- /react-text -->";
-      } else {
-        return "";
-      }
+      nextVal = this._textEnd();
+    }
+
+    if (!nextVal) {
+      return "";
     }
 
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -5,7 +5,12 @@ const render = require("./render");
 const { sequence } = require("./sequence");
 const toPromise = require("./consumers/promise");
 const toNodeStream = require("./consumers/node-stream");
-const { REACT_ID } = require("./symbols");
+const {
+  REACT_EMPTY,
+  REACT_ID,
+  REACT_TEXT_START,
+  REACT_TEXT_END
+} = require("./symbols");
 
 
 const REACT_ID_START = 1;
@@ -43,7 +48,28 @@ class Renderer {
       } else {
         return "";
       }
+    } else if (nextVal === REACT_EMPTY) {
+      if (this.dataReactAttrs) {
+        nextVal = `<!-- react-empty: ${this.reactIdIdx} -->`;
+        this.reactIdIdx++;
+      } else {
+        return "";
+      }
+    } else if (nextVal === REACT_TEXT_START) {
+      if (this.dataReactAttrs) {
+        nextVal = `<!-- react-text: ${this.reactIdIdx} -->`;
+        this.reactIdIdx++;
+      } else {
+        return "";
+      }
+    } else if (nextVal === REACT_TEXT_END) {
+      if (this.dataReactAttrs) {
+        nextVal = "<!-- /react-text -->";
+      } else {
+        return "";
+      }
     }
+
 
     this._checksum = adler32.str(nextVal, this._checksum);
 

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -1,3 +1,6 @@
 module.exports = {
-  REACT_ID: 1
+  REACT_ID: 1,
+  REACT_EMPTY: 2,
+  REACT_TEXT_START: 3,
+  REACT_TEXT_END: 4
 };


### PR DESCRIPTION
This resolves a few differences between how react renders:

- `<!-- react-empty: {id} -->` for components that return null
- `<!-- react-text: {id} -->text<!-- /react-text>` is now rendered when there are multiple siblings to a text node
- False attribute values are not rendered: `disabled="false"`
- True attribute values are rendered without a value (like `disabled`), unless they are explicitly whitelisted attributes (`aria-haspopup` and `aria-expanded`)

Checksums appear to not be consistent with React either, seemingly because of a difference between `adler-32` and `react-dom/lib/adler32` but I'm not going to attempt to fix that here.

If this is acceptable I will write tests, update code comments, and clean lint.

Resolves #83 
