### PR TITLE
Cache miss async rendering

### DIFF
--- a/spec/cache.js
+++ b/spec/cache.js
@@ -29,6 +29,18 @@ const runAllTests = () => {
       }
     }
 
+    it("returns HTML on cache miss for <div>", () => {
+      const childKey = getChildKey();
+      return Bluebird.resolve()
+        .then(() => render(<Parent val="firstA" childKey={childKey} />)
+          .includeDataReactAttrs(false)
+          .toPromise()
+        )
+        .then(html => {
+          expect(html).to.equal("<div>firstA</div>");
+        });
+    });
+
     it("returns cached HTML for <div>", () => {
       const childKey = getChildKey();
       return Bluebird.resolve()
@@ -42,6 +54,18 @@ const runAllTests = () => {
         )
         .then(html => {
           expect(html).to.equal("<div>firstA</div>");
+        });
+    });
+
+    it("returns HTML on cache miss for <Child>", () => {
+      const parentKey = getParentKey();
+      return Bluebird.resolve()
+        .then(() => render(<Parent val="firstB" parentKey={parentKey} />)
+          .includeDataReactAttrs(false)
+          .toPromise()
+        )
+        .then(html => {
+          expect(html).to.equal("<div>firstB</div>");
         });
     });
 

--- a/src/consumers/common.js
+++ b/src/consumers/common.js
@@ -2,9 +2,27 @@ const Promise = require("bluebird");
 
 const { EXHAUSTED } = require("../sequence");
 
+function next (renderer, iter, push) {
+  const max = renderer.batchSize;
+  let nextVal;
 
-const INCOMPLETE = Symbol();
+  try {
+    nextVal = renderer._next();
+  } catch (err) {
+    return Promise.reject(err);
+  }
 
+  if (nextVal === EXHAUSTED) {
+    return EXHAUSTED;
+  } else if (nextVal instanceof Promise) {
+    return nextVal
+    .then(push)
+    .then(() => iter < max && next(renderer, iter + 1, push));
+  } else {
+    push(nextVal);
+    return Promise.resolve(nextVal);
+  }
+}
 
 /**
  * Given a batch size, request values from the source sequence and push them
@@ -19,29 +37,7 @@ const INCOMPLETE = Symbol();
  *                                       be retrieved, or if this the last batch.
  */
 function pullBatch (renderer, pushable) {
-  let iter = renderer.batchSize;
-  while (iter--) {
-    let next;
-    try {
-      next = renderer._next();
-    } catch (err) {
-      return Promise.reject(err);
-    }
-
-    if (
-      next === EXHAUSTED ||
-      next instanceof Promise
-    ) {
-      return next;
-    }
-
-    pushable.push(next);
-  }
-  return INCOMPLETE;
+  return next(renderer, 0, val => typeof val === "string" && pushable.push(val));
 }
 
-
-module.exports = {
-  pullBatch,
-  INCOMPLETE
-};
+module.exports = { pullBatch };

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -87,25 +87,31 @@ class Renderer {
   }
 
   _next () {
-    let nextVal = this.sequence.next();
+    const next = this.sequence.next();
 
-    if (nextVal === REACT_ID) {
-      nextVal = this._rootVal();
-    } else if (nextVal === REACT_EMPTY) {
-      nextVal = this._emptyVal();
-    } else if (nextVal === REACT_TEXT_START) {
-      nextVal = this._textStart();
-    } else if (nextVal === REACT_TEXT_END) {
-      nextVal = this._textEnd();
+    if (!(next && next.then)) {
+      return next;
     }
 
-    if (!nextVal) {
-      return "";
-    }
+    return next.then(nextVal => {
+      if (nextVal === REACT_ID) {
+        nextVal = this._rootVal();
+      } else if (nextVal === REACT_EMPTY) {
+        nextVal = this._emptyVal();
+      } else if (nextVal === REACT_TEXT_START) {
+        nextVal = this._textStart();
+      } else if (nextVal === REACT_TEXT_END) {
+        nextVal = this._textEnd();
+      }
 
-    this._checksum = adler32(nextVal, this._checksum);
+      if (!nextVal) {
+        return "";
+      }
 
-    return nextVal;
+      this._checksum = adler32(nextVal, this._checksum);
+
+      return nextVal;
+    });
   }
 
   toPromise () {

--- a/src/sequence/cache/frame-cache.js
+++ b/src/sequence/cache/frame-cache.js
@@ -1,3 +1,4 @@
+const Promise = require("bluebird");
 const { EXHAUSTED } = require("../common");
 
 const compress = require("../compress");
@@ -32,6 +33,8 @@ class FrameCache {
       if (nextVal instanceof Promise) {
         return nextVal.then(getNextVal);
       }
+
+
       buffer.push(nextVal);
       // Once the FrameCache's sequence has been exhausted, it is safe to compress
       // the buffer and set the value via the specified cache strategy.  Other


### PR DESCRIPTION
When using an async cache strategy and there's a cache miss, segments were being rendered out of order or not at all. This is caused by the fact that the cache segment is returning a promise, but the sequence continued to allow the emission of segments before the cache had resolved.

This PR makes almost everything a promise and builds a chain of promises where the next item in the sequence must wait for the previous item to render.

@divmain @maxgalbu

Resolves #87 

TODO:
- [x] tests
- [x] benchmarks

```
rapscallion{cache-miss}$ npm run benchmark

> rapscallion@2.1.7 benchmark /Users/jkaminetsky/dev/oss/rapscallion
> babel-node benchmark/benchmark.js

Starting benchmark for 10 concurrent render operations...
renderToString took 11.445220171 seconds
rapscallion, no caching took 43.507448408 seconds; ~0.26x faster
rapscallion, caching DIVs took 8.118688945 seconds; ~1.4x faster
rapscallion, caching DIVs (second time) took 8.136480110 seconds; ~1.4x faster
rapscallion, caching Components took 0.644866469 seconds; ~17.74x faster
rapscallion, caching Components (second time) took 13.052715387 seconds; ~0.87x faster
rapscallion (pre-rendered), no caching took 24.778552483 seconds; ~0.46x faster
rapscallion (pre-rendered), caching DIVs took 8.361157752 seconds; ~1.36x faster
rapscallion (pre-rendered), caching DIVs (second time) took 7.835752739 seconds; ~1.46x faster
rapscallion (pre-rendered), caching Components took 13.324269605 seconds; ~0.85x faster
rapscallion (pre-rendered), caching Components (second time) took 13.924382979 seconds; ~0.82x faster
```