### PR TITLE
replace instanceof Array with Array.isArray in traverse

### DIFF
--- a/src/render/traverse.js
+++ b/src/render/traverse.js
@@ -31,7 +31,7 @@ const omittedCloseTags = {
 function renderChildrenArray (seq, children, context) {
   for (let idx = 0; idx < children.length; idx++) {
     const child = children[idx];
-    if (child instanceof Array) {
+    if (Array.isArray(child)) {
       renderChildrenArray(seq, child, context);
     } else {
       traverse({
@@ -47,7 +47,7 @@ function renderChildrenArray (seq, children, context) {
 function renderChildren (seq, children, context) {
   if (children === undefined) { return; }
 
-  if (children instanceof Array) {
+  if (Array.isArray(children)) {
     renderChildrenArray(seq, children, context);
   } else {
     traverse({
@@ -150,7 +150,7 @@ function evalSegment (seq, segment, context) {
   } else if (segment.__prerendered__ === "expression") {
     if (typeof segment.expression === "string") {
       seq.emit(() => htmlStringEscape(segment.expression));
-    } else if (segment.expression instanceof Array) {
+    } else if (Array.isArray(segment.expression)) {
       segment.expression.forEach(subsegment => traverse({
         seq,
         node: subsegment,
@@ -176,7 +176,7 @@ function evalPreRendered (seq, node, context) {
   const prerenderType = node.__prerendered__;
   if (prerenderType === "dom") {
     node.segments.forEach(segment => {
-      if (segment instanceof Array) {
+      if (Array.isArray(segment)) {
         segment.forEach(subsegment => evalSegment(seq, subsegment, context));
       } else {
         evalSegment(seq, segment, context);


### PR DESCRIPTION
I can't reproduce that in tests, but sometimes `instanceof Array` return false for arrays

Example output for
```js
      console.log(Array.isArray(child));
      console.log(child instanceof Array);
      console.log(child)
```
in `renderChildrenArray` function
```
true
false
[ { '$$typeof': Symbol(react.element),
    type: 'div',
    key: '0',
    ref: null,
    props: 
     { className: 'discuss-card_comment discuss-card-comment',
       children: [Object] },
    _owner: null,
    _store: {} },
  { '$$typeof': Symbol(react.element),
    type: 'div',
    key: '1',
    ref: null,
    props: { className: 'discuss-card_footer', children: [Object] },
    _owner: null,
    _store: {} } ]
```

and code that returns that array
```js
	function(question, comment) {
		return [(
			<div className="discuss-card_comment discuss-card-comment" key={0}>
				<div className="discuss-card-comment_info">

				</div>
				<div
					className="discuss-card-comment_text"
					dangerouslySetInnerHTML={{__html: comment.text}}
				/>
			</div>
		), (
			<div className="discuss-card_footer" key={1} >

			</div>
		)];
	}
```

and uncaught exception in traverse
```
Uncaught exception occured: TypeError: Unknown node of type: undefined
    at traverse (/home/fleg/projects/rapscallion/lib/render/traverse.js:330:9)
    at renderChildrenArray (/home/fleg/projects/rapscallion/lib/render/traverse.js:45:7)
    at renderChildren (/home/fleg/projects/rapscallion/lib/render/traverse.js:61:5)
    at /home/fleg/projects/rapscallion/lib/render/traverse.js:99:14
    at Sequence.pushFrame (/home/fleg/projects/rapscallion/lib/sequence/sequence.js:47:7)
    at Sequence.next (/home/fleg/projects/rapscallion/lib/sequence/sequence.js:127:14)
    at Renderer._next (/home/fleg/projects/rapscallion/lib/renderer.js:107:35)
    at pullBatch (/home/fleg/projects/rapscallion/lib/consumers/common.js:25:25)
    at Immediate.asyncBatch (/home/fleg/projects/rapscallion/lib/consumers/promise.js:18:16)
    at runCallback (timers.js:678:20)
    at tryOnImmediate (timers.js:645:5)
    at processImmediate [as _immediateCallback] (timers.js:617:5)
```