### PR TITLE
do not call setState callback in componentWillMount

### DIFF
--- a/spec/exec.js
+++ b/spec/exec.js
@@ -31,3 +31,4 @@ require("./adler32");
 require("./render-error");
 require("./elements");
 require("./attributes");
+require("./set-state");

--- a/spec/lifecycle-methods.js
+++ b/spec/lifecycle-methods.js
@@ -55,31 +55,15 @@ describe("lifecycle methods", () => {
       });
   });
 
-  it("invokes provided setState callbacks", () => {
+  it("do not invoke provided setState callbacks", () => {
     const setStateCb = sinon.spy();
 
-    let _instance;
     const cb = instance => {
-      _instance = instance;
       instance.setState({}, setStateCb);
     };
 
     return render(<C cb={cb} />).includeDataReactAttrs(false).toPromise().then(() => {
-      expect(setStateCb)
-        .to.have.been.calledOnce.and
-        .to.have.been.calledOn(_instance);
-    });
-  });
-
-  it("supports recursive setState invocations", () => {
-    const cb = instance =>
-      instance.setState({ val: "set" }, function () {
-        // eslint-disable-next-line no-invalid-this
-        this.setState({ val: "set-again" });
-      });
-
-    return render(<C cb={cb} />).includeDataReactAttrs(false).toPromise().then(html => {
-      expect(html).to.equal("<div>set-again</div>");
+      expect(setStateCb).to.not.have.been.called;
     });
   });
 });

--- a/spec/set-state.js
+++ b/spec/set-state.js
@@ -1,0 +1,41 @@
+import { checkParity, getRootNode } from "./_util";
+
+describe("setState", () => {
+  const code = `
+  class FooBar extends React.Component {
+    componentWillMount() {
+      this.setState({x: 'bar'});
+    }
+
+    render() {
+      return <div>{this.state.x}</div>;
+    }
+  }
+
+  return FooBar;
+  `;
+
+  const FooBar = getRootNode(code);
+  checkParity(FooBar, {});
+});
+
+describe("setState with callback", () => {
+  const code = `
+  class FooBar extends React.Component {
+    componentWillMount() {
+      this.setState({x: 'bar'}, function() {
+        this.setState({x: 'foo'});
+      });
+    }
+
+    render() {
+      return <div>{this.state.x}</div>;
+    }
+  }
+
+  return FooBar;
+  `;
+
+  const FooBar = getRootNode(code);
+  checkParity(FooBar, {});
+});

--- a/src/render/state.js
+++ b/src/render/state.js
@@ -10,11 +10,10 @@ const {
  *
  * @param      {Function|Object}  newState  An object containing new keys/values
  *                                          or a function that will provide the same.
- * @param      {Function}         cb        A callback that may be provided to setState.
  *
  * @returns    {undefined}                  No return value.
  */
-function syncSetState (newState, cb) {
+function syncSetState (newState) {
   // Mutation is faster and should be safe here.
   this.state = assign(
     this.state,
@@ -22,7 +21,6 @@ function syncSetState (newState, cb) {
       newState(this.state, this.props) :
       newState
   );
-  if (cb) { cb.call(this); }
 }
 
 


### PR DESCRIPTION
Current behavior different from react

for example

```jsx
	var renderToString = require('react-dom/server').renderToString;

	var Component = React.createClass({
		componentWillMount: function() {
			this.setState({bar: true}, function() {
				console.log('after setState');
			});
		},

		render: function() {
			return <div>foo</div>;
		}
	});

	console.log(renderToString(<Component />));
```

output only

```
<div data-reactroot="" data-reactid="1" data-react-checksum="-1450897250">foo</div>
```

and react doesn't supports recursive setState invocations

```jsx
	var renderToString = require('react-dom/server').renderToString;

	var Component = React.createClass({
		componentWillMount: function() {
			this.setState({bar: 'bar'}, function() {
				this.setState({bar: 'foo'});
			});
		},

		render: function() {
			return <div>{this.state.bar}</div>;
		}
	});

	console.log(renderToString(<Component />));
```

output
```
<div data-reactroot="" data-reactid="1" data-react-checksum="-1459220337">bar</div>
```