### PR TITLE
Children that evaluate to true, false and undefined should be allowed

### DIFF
--- a/spec/special-cases.js
+++ b/spec/special-cases.js
@@ -113,4 +113,26 @@ describe("special cases", () => {
       expect(html).to.equal("<div>0</div>");
     });
   });
+  it("renders true, false, null and undefined as nothing", () => {
+    const TrueComponent = () => <div>{true}</div>;
+
+    return render(<TrueComponent />).includeDataReactAttrs(false).toPromise().then(html => {
+      expect(html).to.equal("<div></div>");
+    });
+    const FalseComponent = () => <div>{false}</div>;
+
+    return render(<TrueComponent />).includeDataReactAttrs(false).toPromise().then(html => {
+      expect(html).to.equal("<div></div>");
+    });
+    const NullComponent = () => <div>{null}</div>;
+
+    return render(<TrueComponent />).includeDataReactAttrs(false).toPromise().then(html => {
+      expect(html).to.equal("<div></div>");
+    });
+    const UndefinedComponent = () => <div>{undefined}</div>;
+
+    return render(<TrueComponent />).includeDataReactAttrs(false).toPromise().then(html => {
+      expect(html).to.equal("<div></div>");
+    });
+  });
 });

--- a/src/render/traverse.js
+++ b/src/render/traverse.js
@@ -237,7 +237,9 @@ function traverse ({ seq, node, context, numChildren }) {
     return;
   }
 
-  if (node === null) {
+  // in JSX, all are valid children:
+  // null, undefined, false and true
+  if (node === true || node === false || node === undefined || node === null) {
     emitEmpty(seq);
     return;
   }


### PR DESCRIPTION
According to the [JSX spec](https://facebook.github.io/react/docs/jsx-in-depth.html), there are valid values for children nodes like true, false, null and undefined and only 1 of the 4 was being covered by Rapscallion.  These render as nothing in reactjs and I believe the desired behavior in rapscallion should be the same.  This pops up when using logic in your JSX to conditionally render components.  For example:
```
{someCheck || 
  <ConditionalComponent />}
```
This could easily evaluate to {true} and be a valid child component but cause a `TypeError(Unknown node of type: undefined)` to be thrown in Rapscallion.   