### PR TITLE
WIP: fix error-checking

### DIFF
--- a/spec/template.js
+++ b/spec/template.js
@@ -157,4 +157,15 @@ describe("stream templates", () => {
       expect(segmentCount).to.be.above(1);
     });
   });
+  it("renders empty string", () => {
+    const tmpl = template``;
+
+    let output = "";
+    return resolveStreamOnDone(
+      tmpl.toStream(),
+      segment => output += segment
+    ).then(() => {
+      expect(output).to.equal("");
+    });
+  });
 });

--- a/src/consumers/common.js
+++ b/src/consumers/common.js
@@ -18,7 +18,7 @@ function next (renderer, iter, push) {
   }
 
   if (nextVal === EXHAUSTED) {
-    return EXHAUSTED;
+    return Promise.resolve(EXHAUSTED);
   } else if (nextVal instanceof Promise) {
     return nextVal
     .then(push)


### PR DESCRIPTION
This PR attempts to fix two issues.

Rapsacalion would fail when the [`nextVal` was `EXHAUSTED`](https://github.com/FormidableLabs/rapscallion/compare/master...getkey:fix-error-checking?expand=1#diff-21caecff17bae251453860b4a11ea818R16) because it is expecting a Promise.

The second issue is that sometimes, next may return `false` when [iter >= max](https://github.com/FormidableLabs/rapscallion/compare/master...getkey:fix-error-checking?expand=1#diff-21caecff17bae251453860b4a11ea818L20). When `false` is [passed down to `toNodeStream`](https://github.com/getkey/rapscallion/blob/5d68258816895b0c5e40d74913445e4ce61f32f3/src/consumers/node-stream.js#L29), it fails with the following error:

```
Unhandled rejection TypeError: Invalid non-string/buffer chunk
    at chunkInvalid (_stream_readable.js:274:10)
    at readableAddChunk (_stream_readable.js:213:12)
    at Readable.push (_stream_readable.js:197:10)
    at /home/getkey/devel/cocoon/node_modules/rapscallion/lib/consumers/node-stream.js:38:16
    at tryCatcher (/home/getkey/devel/cocoon/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/home/getkey/devel/cocoon/node_modules/bluebird/js/release/promise.js:512:31)
    at Promise._settlePromise (/home/getkey/devel/cocoon/node_modules/bluebird/js/release/promise.js:569:18)
    at Promise._settlePromise0 (/home/getkey/devel/cocoon/node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/home/getkey/devel/cocoon/node_modules/bluebird/js/release/promise.js:693:18)
    at Async._drainQueue (/home/getkey/devel/cocoon/node_modules/bluebird/js/release/async.js:133:16)
    at Async._drainQueues (/home/getkey/devel/cocoon/node_modules/bluebird/js/release/async.js:143:10)
    at Immediate.Async.drainQueues (/home/getkey/devel/cocoon/node_modules/bluebird/js/release/async.js:17:14)
    at runCallback (timers.js:800:20)
    at tryOnImmediate (timers.js:762:5)
    at processImmediate [as _immediateCallback] (timers.js:733:5)
```
This bug was introduced somewhere between v2.1.7 and v2.1.10.

Unfortunately I don't have enough time to fix this second issue, but I hope my findings will serve as a good starting point. :-)
<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters adhere to the following:

- [x] <!-- checklist item; required -->I have read and will comply with the [contribution guidelines](https://github.com/FormidableLabs/rapscallion/blob/master/CONTRIBUTE.md).
 _(required)_
- [x] <!-- checklist item; required -->I have read and will comply with the [code of conduct](https://github.com/FormidableLabs/rapscallion/blob/master/CONTRIBUTE.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [x] <!-- semver --> patch
- [ ] <!-- semver --> documentation only

