### PR TITLE
Fix: Bluebird console.warn message

### DIFF
--- a/src/consumers/node-stream.js
+++ b/src/consumers/node-stream.js
@@ -16,23 +16,23 @@ function toNodeStream (renderer) {
 
   const read = () => {
     // If source is not ready, defer any reads until the promise resolves.
-    if (!sourceIsReady) { return; }
+    if (!sourceIsReady) { return false; }
 
     sourceIsReady = false;
     const pull = pullBatch(renderer, stream);
 
-    pull.then(result => {
+    return pull.then(result => {
       sourceIsReady = true;
       if (result === EXHAUSTED) {
-        stream.push(null);
+        return stream.push(null);
       } else {
         if (result !== INCOMPLETE) {
           stream.push(result);
         }
-        read();
+        return read();
       }
     }).catch(err => {
-      stream.emit("error", err);
+      return stream.emit("error", err);
     });
   };
 


### PR DESCRIPTION
While using `Renderer#toStream()` a console message from Bluebird is emitted regarding a promise created in `src/consumers/node-stream.js` that was not returned.

**Repro:** Start a server that streams a response using `Renderer#toStream()` and observe the logs in the console. An example application where this behavior is happening can be found [here](https://github.com/cullenjett/react-ssr-boilerplate).

**Versions:** 
- Rapscallion 2.1.13 (with Bluebird 3.5.0)
- React 15.6.1
- Node 8.2.1
- Express 4.15.3

**Error Message:** 
```(node:22461) Warning: a promise was created in a handler at my-repo/node_modules/rapscallion/lib/consumers/node-stream.js:43:9 but was not returned from it, see http://goo.gl/rRqMUw```

-----

Closes #119

<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters adhere to the following:

- [x] <!-- checklist item; required -->I have read and will comply with the [contribution guidelines](https://github.com/FormidableLabs/rapscallion/blob/master/CONTRIBUTE.md).
 _(required)_
- [x] <!-- checklist item; required -->I have read and will comply with the [code of conduct](https://github.com/FormidableLabs/rapscallion/blob/master/CONTRIBUTE.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [x] <!-- semver --> patch
- [ ] <!-- semver --> documentation only

