### PR TITLE
babel-plugin-server Transform Valueless Props

### DIFF
--- a/src/transform/server.js
+++ b/src/transform/server.js
@@ -110,6 +110,18 @@ const prerenderDom = node => {
   return objExpr;
 };
 
+const objectPropertyValue = value => {
+  if (t.isJSXExpressionContainer(value)) {
+    return value.expression;
+  }
+
+  if (value === null || value === undefined) {
+    return t.jSXEmptyExpression();
+  }
+
+  return value;
+};
+
 const getComponentProps = (attributes, children) => attributes
   .map(attr => {
     if (t.isJSXSpreadAttribute(attr)) {
@@ -119,9 +131,7 @@ const getComponentProps = (attributes, children) => attributes
     const { name, value } = attr;
     return t.objectProperty(
       t.identifier(name.name),
-      t.isJSXExpressionContainer(value) ?
-        value.expression :
-        value
+      objectPropertyValue(value)
     );
   })
   .concat([


### PR DESCRIPTION
<!-- maintainerd: DO NOT REMOVE -->


Fixes #73 

`babel-types/ObjectProperty` expects a `babel-types` null literal or empty JSX expression when the value of an attribute is not given.

If the attribute value is `null`, use `.nullLiteral()`.
If the attribute value is `undefined`, use `jSXEmptyExpression`.

There are no tests for `babel-plugin-server` that I can find.

-----

The maintainers of this repo require that all pull request submitters adhere to the following:

- [x] <!-- checklist item; required -->I have read and will comply with the [contribution guidelines](https://github.com/FormidableLabs/rapscallion/blob/master/CONTRIBUTE.md).
 _(required)_
- [x] <!-- checklist item; required -->I have read and will comply with the [code of conduct](https://github.com/FormidableLabs/rapscallion/blob/master/CONTRIBUTE.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [x] <!-- semver --> patch
- [ ] <!-- semver --> documentation only