### PR TITLE
Do not throw when getChildContext is not defined

### DIFF
--- a/src/render/context.js
+++ b/src/render/context.js
@@ -20,7 +20,7 @@ const EMPTY_CONTEXT = Object.freeze({});
  * @return     {Object}                         Child context merged into master context.
  */
 function getChildContext (componentPrototype, instance, context) {
-  if (componentPrototype.childContextTypes) {
+  if (componentPrototype.childContextTypes && instance.getChildContext) {
     return assign(Object.create(null), context, instance.getChildContext());
   }
   return context;


### PR DESCRIPTION
It's a weird use-case, but this doesn't throw in React 15.